### PR TITLE
Model returns knowledge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SB_WEB_FORCE_ASSET_VERSION Int to forced update of external CSS and JavaScript files
 - SB_APP_ROOT_ABSOLUTE_URL The absolute URL of the root of the application
 - show SQL statements in Tracy
+- database load checked, if fails an Exception is thrown
+- if Location redirection fails, a nice redirection HTML page ( redirection.latte ) is displayed
 
 ### Changed
 - APP_COLLECTION -> APP_MAPPING

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SeablastModel uses permanent argument Superglobals $superglobals instead of injection `$m->setSuperglobals($superglobals);` if required by APP_MAPPING, so that it is always easily available
 - FLAG_DEBUG_JSON: Output JSON as HTML instead of application/json so that Tracy is displayed
 - `declare(strict_types=1);` everywhere
+- SB_WEB_FORCE_ASSET_VERSION Int to forced update of external CSS and JavaScript files
+- SB_APP_ROOT_ABSOLUTE_URL The absolute URL of the root of the application
 
 ### Changed
 - APP_COLLECTION -> APP_MAPPING

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Security` in case of vulnerabilities
 
-## [0.1] - YYYY-MM-DD
+## [0.1] - 2023-12-30
 ### Added
 - MVC architecture
 - SeablastConstant class for IDE hinting
@@ -30,11 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Code quality: add Assertions to eliminate PHPStan identified issues
 - added prototype of parametric routing
 - URL maps to template (404 otherwise)
-- Controller: /book and /book/ and /book/?id=1 are all resolved to /book
+- Controller: /item and /item/ and /item/?id=1 are all resolved to /item
 - configuration is handed over to renderLatte
 - GET parameters passed to model in configuration fields SB_GET_ARGUMENT_ID|SB_GET_ARGUMENT_CODE
 - SeablastModelInterface.php to define minimal requirements for a model used by SeablastModel
-- SeablastModel uses permanent argument Superglobals $superglobals instead of injection `$m->setSuperglobals($superglobals);` if required by APP_MAPPING, so that it is always easily available
+- SeablastModel uses permanent argument Superglobals $superglobals (instead of injection `$m->setSuperglobals($superglobals);` if required by APP_MAPPING, so that it is always easily available)
 - FLAG_DEBUG_JSON: Output JSON as HTML instead of application/json so that Tracy is displayed
 - `declare(strict_types=1);` everywhere
 - SB_WEB_FORCE_ASSET_VERSION Int to forced update of external CSS and JavaScript files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - URL maps to template (404 otherwise)
 - Controller: /book and /book/ and /book/?id=1 are all resolved to /book
 - configuration is handed over to renderLatte
+- GET parameters passed to model in configuration fields SB_GET_ARGUMENT_ID|SB_GET_ARGUMENT_CODE
+- SeablastModelInterface.php to define minimal requirements for a model used by SeablastModel
 
 ### Changed
 - APP_COLLECTION -> APP_MAPPING

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `declare(strict_types=1);` everywhere
 - SB_WEB_FORCE_ASSET_VERSION Int to forced update of external CSS and JavaScript files
 - SB_APP_ROOT_ABSOLUTE_URL The absolute URL of the root of the application
+- show SQL statements in Tracy
 
 ### Changed
 - APP_COLLECTION -> APP_MAPPING

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - configuration is handed over to renderLatte
 - GET parameters passed to model in configuration fields SB_GET_ARGUMENT_ID|SB_GET_ARGUMENT_CODE
 - SeablastModelInterface.php to define minimal requirements for a model used by SeablastModel
+- SeablastModel uses permanent argument Superglobals $superglobals instead of injection `$m->setSuperglobals($superglobals);` if required by APP_MAPPING, so that it is always easily available
+- FLAG_DEBUG_JSON: Output JSON as HTML instead of application/json so that Tracy is displayed
+- `declare(strict_types=1);` everywhere
 
 ### Changed
 - APP_COLLECTION -> APP_MAPPING
+- model->getParameters() -> model->knowledge()
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,12 +40,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SB_WEB_FORCE_ASSET_VERSION Int to forced update of external CSS and JavaScript files
 - SB_APP_ROOT_ABSOLUTE_URL The absolute URL of the root of the application
 - show SQL statements in Tracy
-- database load checked, if fails an Exception is thrown
+- SeablastMysqli lazy initialisation; database load checked, if fails an Exception is thrown
 - if Location redirection fails, a nice redirection HTML page ( redirection.latte ) is displayed
 
 ### Changed
 - APP_COLLECTION -> APP_MAPPING
 - model->getParameters() -> model->knowledge()
+- nice Under construction page
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The goal is to be able to create a complex web application ONLY by configuration
 
 ## Model
 SeablastModel uses model field in APP_MAPPING to invoke the model in the App.
-*Model transforms input into knowledge*, therefore the invoked class MUST have a public method `knowledge()` and expect SeablastConfiguration as a constructor argument.
+**Model transforms input into knowledge**, therefore the invoked class MUST have a public method `knowledge()` and expect SeablastConfiguration as a constructor argument.
 - SeablastModel also expects Superglobals $superglobals argument (instead of injection `$m->setSuperglobals($superglobals);` if required by APP_MAPPING), so that the environment variables are always easily available. (Especially important for APIs.)
 
 The minimal requirements are to be implemented by SeablastModelInterface.
@@ -36,12 +36,12 @@ The minimal requirements are to be implemented by SeablastModelInterface.
 ## App expectation
 - SeablastMysqli expects `log` directory to store query.log there
 
-## Directory description
+## Framework directory description
 | Directory | Description |
 |-----|------|
-| .github/ | automations |
+| .github/ | Automations |
 | cache/ | Latte cache - this is just for development as production-wise, there will be cache/ directory in the root of the app |
 | conf/ | Default configuration for a Seablast app and for PHPStan |
-| log/ | logs - this is just for development as production-wise, there will be log/ directory in the root of the app |
+| log/ | Logs - this is just for development as production-wise, there will be `log` directory in the root of the app |
 | src/ | Seablast classes |
 | templates/ | Latte templates to be inherited |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Seablast for PHP
-[![Total Downloads](https://img.shields.io/packagist/dt/workofstan/seablast.svg)](https://packagist.org/packages/workofstan/seablast)
-[![Latest Stable Version](https://img.shields.io/packagist/v/workofstan/seablast.svg)](https://packagist.org/packages/workofstan/seablast)
+[![Total Downloads](https://img.shields.io/packagist/dt/seablast/seablast.svg)](https://packagist.org/packages/seablast/seablast)
+[![Latest Stable Version](https://img.shields.io/packagist/v/seablast/seablast.svg)](https://packagist.org/packages/seablast/seablast)
 
 A minimalist MVC framework added by composer.
 The goal is to be able to create a complex web application ONLY by configuration.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The minimal requirements are to be implemented by SeablastModelInterface.
 - Tracy
 
 ## Notes
-- the constant `APP_DIR` = the directory of the current application (or the library if built directly)
+- the constant `APP_DIR` = the directory of the current application (or the library, if deployed directly)
 - don't start the value of a constant for a configuration field in the app.conf.php with SB to prevent value collision
 
 ## App expectation

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # Seablast for PHP
+[![Total Downloads](https://img.shields.io/packagist/dt/workofstan/seablast.svg)](https://packagist.org/packages/workofstan/seablast)
+[![Latest Stable Version](https://img.shields.io/packagist/v/workofstan/seablast.svg)](https://packagist.org/packages/workofstan/seablast)
+
 A minimalist MVC framework added by composer.
-The goal is to be able to create a complex web application only by configuration.
+The goal is to be able to create a complex web application ONLY by configuration.
 (The future is in an easy to maintain technology.)
+- Also render templates are optional.
+- Last but not least, the unique business logic MUST by implemented as models.
 
 - See <https://github.com/WorkOfStan/seablast-dist/> for example of how to use it.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ SeablastModel uses model field in APP_MAPPING to invoke the model in the App.
 The minimal requirements are to be implemented by SeablastModelInterface.
 
 - If model replies with `rest` property, API response is triggered instead of HTML UI.
-- If model replies with `redirection` property, then `url` and optionally `httpCode` properties trigger redirection (instead of HTML UI).
+- If model replies with `redirection` property, then `url` and optionally `httpCode` (301, 302 or 303) properties trigger redirection (instead of HTML UI).
 
 ## Stack
 - PHP7.2+

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ The goal is to be able to create a complex web application only by configuration
 - everything can be overriden in the web app's `conf/app.conf.php` or even in its local deployment `conf/app.conf.local.php`
 
 ## Model
-SeablastModel uses model field in APP_COLLECTION to invoke the model in the App. The invoked class MUST have a public method `getParameters()`.
+SeablastModel uses model field in APP_MAPPING to invoke the model in the App.
+The invoked class MUST have a public method `getParameters()` and accept SeablastConfiguration as a constructor argument.
+The minimal requirements are to be implemented by SeablastModelInterface.
 
 ## Stack
 - PHP7.2+
@@ -17,6 +19,7 @@ SeablastModel uses model field in APP_COLLECTION to invoke the model in the App.
 
 ## Notes
 - the constant `APP_DIR` = the directory of the current application (or the library if built directly)
+- don't start the name of a configuration field in the app.conf.php with SB to prevent value collision
 
 ## Directory description
 | Directory | Description |

--- a/README.md
+++ b/README.md
@@ -25,12 +25,15 @@ The minimal requirements are to be implemented by SeablastModelInterface.
 - the constant `APP_DIR` = the directory of the current application (or the library if built directly)
 - don't start the value of a constant for a configuration field in the app.conf.php with SB to prevent value collision
 
+## App expectation
+- SeablastMysqli expects log directory to store query_log.txt there
+
 ## Directory description
 | Directory | Description |
 |-----|------|
 | .github/ | automations |
 | cache/ | Latte cache - this is just for development as production-wise, there will be cache/ directory in the root of the app |
 | conf/ | Default configuration for a Seablast app and for PHPStan |
-| log/ | logs - this is just for development as production-wise, there will be logs/ directory in the root of the app |
+| log/ | logs - this is just for development as production-wise, there will be log/ directory in the root of the app |
 | src/ | Seablast classes |
 | templates/ | Latte templates to be inherited |

--- a/README.md
+++ b/README.md
@@ -20,13 +20,14 @@ The minimal requirements are to be implemented by SeablastModelInterface.
 
 ## Notes
 - the constant `APP_DIR` = the directory of the current application (or the library if built directly)
-- don't start the name of a configuration field in the app.conf.php with SB to prevent value collision
+- don't start the value of a constant for a configuration field in the app.conf.php with SB to prevent value collision
 
 ## Directory description
 | Directory | Description |
 |-----|------|
 | .github/ | automations |
 | cache/ | Latte cache - this is just for development as production-wise, there will be cache/ directory in the root of the app |
+| conf/ | Default configuration for a Seablast app and for PHPStan |
 | log/ | logs - this is just for development as production-wise, there will be logs/ directory in the root of the app |
 | src/ | Seablast classes |
 | templates/ | Latte templates to be inherited |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The minimal requirements are to be implemented by SeablastModelInterface.
 - don't start the value of a constant for a configuration field in the app.conf.php with SB to prevent value collision
 
 ## App expectation
-- SeablastMysqli expects log directory to store query_log.txt there
+- SeablastMysqli expects log directory to store query.log there
 
 ## Directory description
 | Directory | Description |

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ A minimalist MVC framework added by composer.
 The goal is to be able to create a complex web application only by configuration.
 (The future is in an easy to maintain technology.)
 
+- See <https://github.com/WorkOfStan/seablast-dist/> for example of how to use it.
+
 ## Configuration
 - the default environment parameters are set in the [conf/default.conf.php](conf/default.conf.php)
 - everything can be overriden in the web app's `conf/app.conf.php` or even in its local deployment `conf/app.conf.local.php`

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ The goal is to be able to create a complex web application only by configuration
 
 ## Model
 SeablastModel uses model field in APP_MAPPING to invoke the model in the App.
-The invoked class MUST have a public method `getParameters()` and accept SeablastConfiguration as a constructor argument.
+Model transforms input into knowledge, therefore the invoked class MUST have a public method `knowledge()` and expect SeablastConfiguration as a constructor argument.
+Also SeablastModel expects Superglobals $superglobals argument (instead of injection `$m->setSuperglobals($superglobals);` if required by APP_MAPPING), so that the environment variables are always easily available. (Especially important for APIs.)
 The minimal requirements are to be implemented by SeablastModelInterface.
 
 ## Stack

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Also SeablastModel expects Superglobals $superglobals argument (instead of injec
 The minimal requirements are to be implemented by SeablastModelInterface.
 
 - If model replies with `rest` property, API response is triggered instead of HTML UI.
-- If model replies with `redirection` property, then `url` and optionally `httpCode` properties trigger redirection (instead of HTML UI)-
+- If model replies with `redirection` property, then `url` and optionally `httpCode` properties trigger redirection (instead of HTML UI).
 
 ## Stack
 - PHP7.2+

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Model transforms input into knowledge, therefore the invoked class MUST have a p
 Also SeablastModel expects Superglobals $superglobals argument (instead of injection `$m->setSuperglobals($superglobals);` if required by APP_MAPPING), so that the environment variables are always easily available. (Especially important for APIs.)
 The minimal requirements are to be implemented by SeablastModelInterface.
 
+- If model replies with `rest` property, API response is triggered instead of HTML UI.
+- If model replies with `redirection` property, then `url` and optionally `httpCode` properties trigger redirection (instead of HTML UI)-
+
 ## Stack
 - PHP7.2+
 - Latte

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ The goal is to be able to create a complex web application ONLY by configuration
 
 ## Model
 SeablastModel uses model field in APP_MAPPING to invoke the model in the App.
-Model transforms input into knowledge, therefore the invoked class MUST have a public method `knowledge()` and expect SeablastConfiguration as a constructor argument.
-Also SeablastModel expects Superglobals $superglobals argument (instead of injection `$m->setSuperglobals($superglobals);` if required by APP_MAPPING), so that the environment variables are always easily available. (Especially important for APIs.)
+*Model transforms input into knowledge*, therefore the invoked class MUST have a public method `knowledge()` and expect SeablastConfiguration as a constructor argument.
+- SeablastModel also expects Superglobals $superglobals argument (instead of injection `$m->setSuperglobals($superglobals);` if required by APP_MAPPING), so that the environment variables are always easily available. (Especially important for APIs.)
+
 The minimal requirements are to be implemented by SeablastModelInterface.
 
 - If model replies with `rest` property, API response is triggered instead of HTML UI.
@@ -33,7 +34,7 @@ The minimal requirements are to be implemented by SeablastModelInterface.
 - don't start the value of a constant for a configuration field in the app.conf.php with SB to prevent value collision
 
 ## App expectation
-- SeablastMysqli expects log directory to store query.log there
+- SeablastMysqli expects `log` directory to store query.log there
 
 ## Directory description
 | Directory | Description |

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,7 @@ All planned changes to this project will be documented in this file.
 
 ## UX
 - 231207, nice 404 (adapt redirection.latte to special operational pages layout)
+- 231229, UI for db administration
 
 ## Governance
 - 231128, replace `.github/linters/*.yml` and `.github/workflows/*.yml` by Seablast versions, probably `WorkOfStan/Seablast-github/.github/workflows/`

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 All planned changes to this project will be documented in this file.
 
 ## UX
-- 231207, nice 404
+- 231207, nice 404 (adapt redirection.latte to special operational pages layout)
 
 ## Governance
 - 231128, replace `.github/linters/*.yml` and `.github/workflows/*.yml` by Seablast versions, probably `WorkOfStan/Seablast-github/.github/workflows/`

--- a/conf/default.conf.php
+++ b/conf/default.conf.php
@@ -14,6 +14,7 @@ return static function (SeablastConfiguration $SBConfig): void {
         //->activate('as') // debug
         //->deactivate('mon') // debug
         ->deactivate(SeablastConstant::ADMIN_MAIL_ENABLED) // default is not sending emails
+        //->activate(SeablastConstant::FLAG_DEBUG_JSON) // JSON would be displayed directly with Tracy
     ;
     $SBConfig
         // Debug

--- a/conf/default.conf.php
+++ b/conf/default.conf.php
@@ -25,7 +25,7 @@ return static function (SeablastConfiguration $SBConfig): void {
         ->setInt(SeablastConstant::SB_ERROR_REPORTING, E_ALL & ~E_NOTICE)
         ->setInt(SeablastConstant::SB_SESSION_SET_COOKIE_LIFETIME, 60 * 60 * 24 * 2) // 2 days
         ->setInt(SeablastConstant::SB_SESSION_SET_COOKIE_PARAMS_LIFETIME, 60 * 60 * 3) // 3 hours
-        ->setString(SeablastConstant::SB_SESSION_SET_COOKIE_PARAMS_PATH, '/')
+        ->setString(SeablastConstant::SB_SESSION_SET_COOKIE_PARAMS_PATH, '/') // TODO just app directory
         ->setInt(SeablastConstant::SB_SETLOCALE_CATEGORY, LC_CTYPE)
         ->setString(SeablastConstant::SB_SETLOCALE_LOCALES, 'cs_CZ.UTF-8')
         ->setString(SeablastConstant::SB_ENCODING, 'UTF-8')
@@ -34,6 +34,6 @@ return static function (SeablastConfiguration $SBConfig): void {
         ->setArrayString(SeablastConstant::DEBUG_IP_LIST, []) // default list with IPs to show Tracy
         // Latte templates
         ->setString(SeablastConstant::LATTE_TEMPLATE, 'templates')
-        ->setString(SeablastConstant::LATTE_CACHE, 'cache')
+        ->setString(SeablastConstant::LATTE_CACHE, APP_DIR . '/cache')
     ;
 };

--- a/conf/default.conf.php
+++ b/conf/default.conf.php
@@ -11,16 +11,16 @@ use Seablast\Seablast\SeablastConstant;
 return static function (SeablastConfiguration $SBConfig): void {
     $SBConfig->flag
         ->activate(SeablastConstant::FLAG_WEB_RUNNING) // debug
-        ->activate('as') // debug
-        ->deactivate('mon') // debug
+        //->activate('as') // debug
+        //->deactivate('mon') // debug
         ->deactivate(SeablastConstant::ADMIN_MAIL_ENABLED) // default is not sending emails
     ;
     $SBConfig
         // Debug
-        ->setInt('a', 23)
-        ->setInt('b', 45)
-        ->setString('test-string', 'default-value') // debug
-        ->setArrayString('test-array-string', ['a', 'y', 'omega'])
+        //->setInt('a', 23)
+        //->setInt('b', 45)
+        //->setString('test-string', 'default-value') // debug
+        //->setArrayString('test-array-string', ['a', 'y', 'omega'])
         // Environment
         ->setInt(SeablastConstant::SB_ERROR_REPORTING, E_ALL & ~E_NOTICE)
         ->setInt(SeablastConstant::SB_SESSION_SET_COOKIE_LIFETIME, 60 * 60 * 24 * 2) // 2 days

--- a/defineAppDir.php
+++ b/defineAppDir.php
@@ -1,10 +1,11 @@
 <?php
 
 // Keep this in a separate file in order to avoid declaring new symbols in index.php
-if (file_exists(__DIR__ . '/../../autoload.php')) {
-    // called as library
-    define('APP_DIR', __DIR__ . '/../../..');
-} else {
-    // direct usage (TODO: consider whether necessary at all)
-    define('APP_DIR', __DIR__);
-}
+define(
+    'APP_DIR',
+    file_exists(__DIR__ . '/../../autoload.php')
+        // called as library
+        ? __DIR__ . '/../../..'
+        // direct usage (TODO: consider whether necessary at all)
+        : __DIR__
+);

--- a/index.php
+++ b/index.php
@@ -27,5 +27,5 @@ Debugger::enable($developmentEnvironment ? Debugger::DEVELOPMENT : Debugger::PRO
 // Wrap _GET, _POST, _SESSION and _SERVER for sanitizing and testing
 $superglobals = new Superglobals($_GET, $_POST, $_SERVER, $_SESSION);
 $controller = new SeablastController($setup->getConfiguration(), $superglobals);
-$model = new SeablastModel($controller);
+$model = new SeablastModel($controller, $superglobals);
 $view = new SeablastView($model);

--- a/src/SeablastConfiguration.php
+++ b/src/SeablastConfiguration.php
@@ -55,13 +55,14 @@ class SeablastConfiguration
     {
         $phinx = $this->dbmsReadPhinx();
         // todo Assert:: environment dle SB_phinx or default environment ... Parametry foreach Assert:: string
-        $environment = 'developmnent'; // todo config ?? $phinx['environments']['default_environment']
+        $environment = 'development'; // todo config ?? $phinx['environments']['default_environment']
+        Assert::keyExists($phinx['environments'], $environment, "Phinx environment `{$environment}` isn't defined");
         $this->connection = new SeablastMysqli(
             $phinx['environments'][$environment]['host'], // todo fix localhost
             $phinx['environments'][$environment]['user'],
             $phinx['environments'][$environment]['pass'],
             $phinx['environments'][$environment]['name'],
-            $phinx['environments'][$environment]['port'] ?? null
+            (int) $phinx['environments'][$environment]['port'] ?? null
         );
         // todo does this really differentiate between successful connection, failed connection and no connection?
         Assert::isAOf($this->connection, '\Seablast\Seablast\SeablastMysqli');
@@ -77,7 +78,7 @@ class SeablastConfiguration
     private static function dbmsReadPhinx(): array
     {
         if (!file_exists(APP_DIR . '/conf/phinx.local.php')) {
-            throw new \Exception('Give credentials to use database');
+            throw new \Exception('Provide credentials to use database');
         }
         return require APP_DIR . '/conf/phinx.local.php';
     }

--- a/src/SeablastConfiguration.php
+++ b/src/SeablastConfiguration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seablast\Seablast;
 
 use Seablast\Seablast\SeablastConfigurationException;

--- a/src/SeablastConfiguration.php
+++ b/src/SeablastConfiguration.php
@@ -73,8 +73,8 @@ class SeablastConfiguration
     }
 
     /**
-     * TODO ignore: `Method Seablast\Seablast\SeablastConfiguration::dbmsReadPhinx() should return array but
-     * TODO ignore: return statement is missing.`
+     * Read the database connection parameters from an external phinx configuration
+     *
      * @return array<mixed>
      * @throws \Exception
      */

--- a/src/SeablastConfiguration.php
+++ b/src/SeablastConfiguration.php
@@ -93,7 +93,7 @@ class SeablastConfiguration
      */
     public function dbmsStatus(): bool
     {
-        return !is_a($this->connection, '\mysqli');
+        return is_a($this->connection, '\mysqli');
     }
 
     /**

--- a/src/SeablastConfiguration.php
+++ b/src/SeablastConfiguration.php
@@ -79,7 +79,7 @@ class SeablastConfiguration
         if (!file_exists(APP_DIR . '/conf/phinx.local.php')) {
             throw new \Exception('Give credentials to use database');
         }
-        include APP_DIR . '/conf/phinx.local.php'; // which contains the return statement
+        return require APP_DIR . '/conf/phinx.local.php';
     }
 
     /**

--- a/src/SeablastConfiguration.php
+++ b/src/SeablastConfiguration.php
@@ -83,6 +83,16 @@ class SeablastConfiguration
     }
 
     /**
+     * Returns true on connected, false on not connected
+     * So that SQL Bar Panel is not requested in vain
+     * @return bool
+     */
+    public function dbmsStatus(): bool
+    {
+        return !is_null($this->connection);
+    }
+
+    /**
      * Check existence of a property within configuration
      *
      * @param string $property

--- a/src/SeablastConfiguration.php
+++ b/src/SeablastConfiguration.php
@@ -40,7 +40,7 @@ class SeablastConfiguration
     public function dbms(): SeablastMysqli
     {
         //Lazy initialisation
-        if (is_null($this->connection)) {
+        if (!$this->dbmsStatus()) {
             Debugger::barDump('Creating database connection');
             $this->dbmsCreate();
         }
@@ -56,13 +56,16 @@ class SeablastConfiguration
         $phinx = $this->dbmsReadPhinx();
         // todo Assert:: environment dle SB_phinx or default environment ... Parametry foreach Assert:: string
         $environment = 'development'; // todo config ?? $phinx['environments']['default_environment']
+        Assert::isArray($phinx['environments']);
         Assert::keyExists($phinx['environments'], $environment, "Phinx environment `{$environment}` isn't defined");
+        $port = isset($phinx['environments'][$environment]['port'])
+            ? (int) $phinx['environments'][$environment]['port'] : null;
         $this->connection = new SeablastMysqli(
             $phinx['environments'][$environment]['host'], // todo fix localhost
             $phinx['environments'][$environment]['user'],
             $phinx['environments'][$environment]['pass'],
             $phinx['environments'][$environment]['name'],
-            (int) $phinx['environments'][$environment]['port'] ?? null
+            $port
         );
         // todo does this really differentiate between successful connection, failed connection and no connection?
         Assert::isAOf($this->connection, '\Seablast\Seablast\SeablastMysqli');
@@ -90,7 +93,7 @@ class SeablastConfiguration
      */
     public function dbmsStatus(): bool
     {
-        return !is_null($this->connection);
+        return !is_a($this->connection, '\mysqli');
     }
 
     /**

--- a/src/SeablastConfigurationException.php
+++ b/src/SeablastConfigurationException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seablast\Seablast;
 
 class SeablastConfigurationException extends \Exception

--- a/src/SeablastConstant.php
+++ b/src/SeablastConstant.php
@@ -15,7 +15,7 @@ class SeablastConstant
      */
     public const FLAG_WEB_RUNNING = 'SB:web:running';
     /**
-     * @var string Running or under construction
+     * @var string Redirection database should be looked up (unused so far)
      */
     public const FLAG_CHECK_REDIRECTOR = 'SB:redirector:running';
     /**

--- a/src/SeablastConstant.php
+++ b/src/SeablastConstant.php
@@ -19,6 +19,10 @@ class SeablastConstant
      */
     public const FLAG_CHECK_REDIRECTOR = 'SB:redirector:running';
     /**
+     * @var string Output JSON as HTML instead of application/json so that Tracy is displayed
+     */
+    public const FLAG_DEBUG_JSON = 'SB:debug:json';
+    /**
      * @var string Level of PHP built-in error_reporting
      */
     public const SB_ERROR_REPORTING = 'SB:error_reporting';

--- a/src/SeablastConstant.php
+++ b/src/SeablastConstant.php
@@ -101,4 +101,13 @@ class SeablastConstant
      * @var string Name of an expected and accepted string GET argument
      */
     public const SB_GET_ARGUMENT_CODE = 'SB_GET_ARGUMENT_CODE';
+    /**
+     * @var string Int to forced update of external CSS and Javascript files
+     * TODO use this in seablast-dist
+     */
+    public const SB_WEB_FORCE_ASSET_VERSION = 'SB_WEB_FORCE_ASSET_VERSION';
+    /**
+     * @var string The absolute URL of the root of the application
+     */
+    public const SB_APP_ROOT_ABSOLUTE_URL = 'SB_APP_ROOT_ABSOLUTE_URL';
 }

--- a/src/SeablastConstant.php
+++ b/src/SeablastConstant.php
@@ -6,6 +6,7 @@ namespace Seablast\Seablast;
 
 /**
  * @api
+ * Each string MUST start with SB to avoid unintended value collision
  */
 class SeablastConstant
 {
@@ -59,29 +60,37 @@ class SeablastConstant
      * TODO: make sure this is needed
      * @var string
      */
-    public const BACKYARD_LOGGING_LEVEL = 'BACKYARD_LOGGING_LEVEL';
+    public const BACKYARD_LOGGING_LEVEL = 'SB:BACKYARD_LOGGING_LEVEL';
     /**
      * @var string flag whether to send emails to admin
      */
-    public const ADMIN_MAIL_ENABLED = 'ADMIN_MAIL:ENABLED';
+    public const ADMIN_MAIL_ENABLED = 'SB:ADMIN_MAIL:ENABLED';
     /**
      * @var string string admin's email address
      */
-    public const ADMIN_MAIL_ADDRESS = 'ADMIN_MAIL:ADDRESS';
+    public const ADMIN_MAIL_ADDRESS = 'SB:ADMIN_MAIL:ADDRESS';
     /**
      * @var string string[] IP addresses where to show Tracy
      */
-    public const DEBUG_IP_LIST = 'DEBUG_IP_LIST';
+    public const DEBUG_IP_LIST = 'SB:DEBUG_IP_LIST';
     /**
      * @var string string[] mapping slugs to templates and tables
      */
-    public const APP_MAPPING = 'APP_MAPPING';
+    public const APP_MAPPING = 'SB:APP_MAPPING';
     /**
      * @var string string with path to directory with Latte templates
      */
-    public const LATTE_TEMPLATE = 'LATTE_TEMPLATE';
+    public const LATTE_TEMPLATE = 'SB:LATTE_TEMPLATE';
     /**
      * @var string string with path to directory with cache for Latte
      */
-    public const LATTE_CACHE = 'LATTE_CACHE';
+    public const LATTE_CACHE = 'SB:LATTE_CACHE';
+    /**
+     * @var string Name of an expected and accepted numeric GET argument
+     */
+    public const SB_GET_ARGUMENT_ID = 'SB_GET_ARGUMENT_ID';
+    /**
+     * @var string Name of an expected and accepted string GET argument
+     */
+    public const SB_GET_ARGUMENT_CODE = 'SB_GET_ARGUMENT_CODE';
 }

--- a/src/SeablastConstant.php
+++ b/src/SeablastConstant.php
@@ -15,6 +15,10 @@ class SeablastConstant
      */
     public const FLAG_WEB_RUNNING = 'SB:web:running';
     /**
+     * @var string Running or under construction
+     */
+    public const FLAG_CHECK_REDIRECTOR = 'SB:redirector:running';
+    /**
      * @var string Level of PHP built-in error_reporting
      */
     public const SB_ERROR_REPORTING = 'SB:error_reporting';

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seablast\Seablast;
 
 use Seablast\Seablast\SeablastConfiguration;

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -248,9 +248,9 @@ class SeablastController
     {
         Assert::string($this->superglobals->server['REQUEST_URI']);
         $appPath = self::removeSuffix(
-                (pathinfo($_SERVER['SCRIPT_NAME'], PATHINFO_DIRNAME) === '/')
-                    ? '' : pathinfo($_SERVER['SCRIPT_NAME'], PATHINFO_DIRNAME),
-                '/vendor/seablast/seablast'
+            (pathinfo($_SERVER['SCRIPT_NAME'], PATHINFO_DIRNAME) === '/')
+                ? '' : pathinfo($_SERVER['SCRIPT_NAME'], PATHINFO_DIRNAME),
+            '/vendor/seablast/seablast'
         );
         $urlToBeProcessed = self::removePrefix($this->superglobals->server['REQUEST_URI'], $appPath);
         $this->makeSureUrlIsParametric($urlToBeProcessed);

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -129,6 +129,8 @@ class SeablastController
             }
         }
         // Addition to configuration with info derived from superglobals
+        $scriptName = filter_var($this->superglobals->server['SCRIPT_NAME'], FILTER_SANITIZE_URL);
+        Assert::string($scriptName);
         $this->configuration->setString(
             SeablastConstant::SB_APP_ROOT_ABSOLUTE_URL,
             'http' .
@@ -136,7 +138,7 @@ class SeablastController
             '://' .
             $this->superglobals->server['HTTP_HOST'] .
             $this->removeSuffix(
-                filter_var($this->superglobals->server['SCRIPT_NAME'], FILTER_SANITIZE_URL),
+                $scriptName,
                 '/vendor/seablast/seablast/index.php'
             )
         );

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -34,7 +34,7 @@ class SeablastController
         // Wrapped _GET, _POST, _SESSION and _SERVER for sanitizing and testing
         $this->superglobals = $superglobals;
         $this->configuration = $configuration;
-        Debugger::barDump($this->configuration, 'configuration');
+        Debugger::barDump($this->configuration, 'Configuration at SBController start');
         $this->pageUnderConstruction();
         $this->applyConfiguration();
         $this->route();
@@ -128,6 +128,18 @@ class SeablastController
                 }
             }
         }
+        // Addition to configuration with info derived from superglobals
+        $this->configuration->setString(
+            SeablastConstant::SB_APP_ROOT_ABSOLUTE_URL,
+            'http' .
+            (($this->superglobals->server['SERVER_PORT'] === 443) ? 's' : '') .
+            '://' .
+            $this->superglobals->server['HTTP_HOST'] .
+            $this->removeSuffix(
+                filter_var($this->superglobals->server['SCRIPT_NAME'], FILTER_SANITIZE_URL),
+                '/vendor/seablast/seablast/index.php'
+            )
+        );
     }
 
     /**

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -266,6 +266,7 @@ class SeablastController
         //F(request type = verb/accepted type, url, url params, auth, language)
         // --> model & params & view type (html, json)
         //
+        // TODO if deployed standalone, ends with exception `No array string for the property SB:APP_MAPPING`. OK?
         $mapping = $this->configuration->getArrayArrayString(SeablastConstant::APP_MAPPING);
         if (!isset($mapping[$this->uriPath])) {
             $this->page404("Route {$this->uriPath} not found");

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -169,7 +169,8 @@ class SeablastController
             $phinx['environments'][$environment]['name'],
             $phinx['environments'][$environment]['port'] ?? null,
         );
-        // todo Assert:: connection 
+        // todo Assert:: connection
+        // todo charset nastavit zde, nikoli injection apod
     }
 
     private static function dbmsReadPhinx(): array

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -173,7 +173,10 @@ class SeablastController
         $this->uriPath = $parsedUrl['path']; // Outputs: /myapp/products
         // so that /book and /book/ and /book/?id=1 are all resolved to /book
         $this->uriPath = self::removeSuffix($this->uriPath, '/');
-        // TODO refactor the above
+        if (empty($this->uriPath)) {
+            // so that homepage works
+            $this->uriPath = '/';
+        }
         $this->uriQuery = $parsedUrl['query'] ?? ''; // Outputs: category=books&id=123
         //
         // You can further parse the query string if needed

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -242,7 +242,7 @@ class SeablastController
             'appPath' => $appPath,
             'path' => $this->uriPath,
             'query' => $this->uriQuery,
-        ]);
+        ], 'route resolved');
         //phpinfo();exit;//debug
         //F(request type = verb/accepted type, url, url params, auth, language)
         // --> model & params & view type (html, json)

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -171,10 +171,10 @@ class SeablastController
 
         // Accessing the individual components
         $this->uriPath = $parsedUrl['path']; // Outputs: /myapp/products
-        // so that /book and /book/ and /book/?id=1 are all resolved to /book
+        // so that /item and /item/ and /item/?id=1 are all resolved to /book
         $this->uriPath = self::removeSuffix($this->uriPath, '/');
         if (empty($this->uriPath)) {
-            // so that homepage works
+            // so that the homepage has non empty path
             $this->uriPath = '/';
         }
         $this->uriQuery = $parsedUrl['query'] ?? ''; // Outputs: category=books&id=123

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -168,12 +168,12 @@ class SeablastController
         // makes use of $this->superglobals
         /*
           // Redirector -> friendly url / parametric url
-          if !flag redirector_off
+          if FLAG_CHECK_REDIRECTOR
           ..If Select  * where url
           ....mSUIP //rekurze
 
           // Friendly url -> parametric url
-          If !flag frienflyURL_off
+          If !flag frienflyURL_off //TODO v APP_MAPPING musí být jméno sloupce_LANG, kde hledat
           ..If Select * where url
           ....mSUIP //rekurze
 

--- a/src/SeablastFlag.php
+++ b/src/SeablastFlag.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seablast\Seablast;
 
 use Webmozart\Assert\Assert;

--- a/src/SeablastModel.php
+++ b/src/SeablastModel.php
@@ -4,6 +4,7 @@ namespace Seablast\Seablast;
 
 use Tracy\Debugger;
 use Webmozart\Assert\Assert;
+use stdClass;
 
 class SeablastModel
 {
@@ -13,7 +14,7 @@ class SeablastModel
     public $mapping;
     /** @var SeablastController */
     private $controller;
-    /** @var array<mixed> TODO: use object instead */
+    /** @var array<mixed>|stdClass TODO: use only object instead */
     private $viewParameters = []; // null;
 
     public function __construct(SeablastController $controller)
@@ -40,9 +41,9 @@ class SeablastModel
 
     /**
      * TODO: change to object as parameters for Latte render (yes, Latte supports object even for PHP7.2 in 2.x latest)
-     * @return array<mixed>
+     * @return array<mixed>|stdClass
      */
-    public function getParameters(): array
+    public function getParameters()
     {
         //if (is_null($this->viewParameters)) {
         //    // no parameters

--- a/src/SeablastModel.php
+++ b/src/SeablastModel.php
@@ -4,6 +4,7 @@ namespace Seablast\Seablast;
 
 use Tracy\Debugger;
 use Webmozart\Assert\Assert;
+use Seablast\Seablast\SeablastController;
 use stdClass;
 
 class SeablastModel
@@ -24,7 +25,7 @@ class SeablastModel
         $this->mapping = $this->controller->mapping;
         if (isset($this->mapping['model'])) {
             $className = $this->mapping['model'];
-            $m = new $className();
+            $m = new $className($this->controller->getConfiguration());
             Assert::methodExists($m, 'getParameters', "{$className} model MUST have method getParameters()");
             $this->viewParameters = $m->getParameters();
         }

--- a/src/SeablastModel.php
+++ b/src/SeablastModel.php
@@ -1,33 +1,41 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seablast\Seablast;
 
 use Tracy\Debugger;
 use Webmozart\Assert\Assert;
 use Seablast\Seablast\SeablastController;
+use Seablast\Seablast\Superglobals;
 use stdClass;
 
 class SeablastModel
 {
     use \Nette\SmartObject;
 
-    /** @var string[] mapping of URL to processing */
-    public $mapping;
     /** @var SeablastController */
     private $controller;
+    /** @var string[] mapping of URL to processing */
+    public $mapping;
     /** @var array<mixed>|stdClass TODO: use only object instead */
     private $viewParameters = []; // null;
 
-    public function __construct(SeablastController $controller)
+    /**
+     *
+     * @param SeablastController $controller
+     * @param Superglobals $superglobals
+     */
+    public function __construct(SeablastController $controller, Superglobals $superglobals)
     {
         $this->controller = $controller;
         Debugger::barDump($this->controller, 'Controller'); // debug
         $this->mapping = $this->controller->mapping;
         if (isset($this->mapping['model'])) {
             $className = $this->mapping['model'];
-            $m = new $className($this->controller->getConfiguration());
-            Assert::methodExists($m, 'getParameters', "{$className} model MUST have method getParameters()");
-            $this->viewParameters = $m->getParameters();
+            $m = new $className($this->controller->getConfiguration(), $superglobals);
+            Assert::methodExists($m, 'knowledge', "{$className} model MUST have method knowledge()");
+            $this->viewParameters = $m->knowledge();
         }
     }
 

--- a/src/SeablastModelInterface.php
+++ b/src/SeablastModelInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Seablast\Seablast;
+
+use Seablast\Seablast\SeablastConfiguration;
+use stdClass;
+
+/**
+ * Definition of a model used by SeablastModel
+ *
+ * Usage: class AbcModel implements SeablastModelInterface
+ */
+interface SeablastModelInterface
+{
+    public function __construct(SeablastConfiguration $configuration);
+    public function getParameters(): stdClass;
+}

--- a/src/SeablastModelInterface.php
+++ b/src/SeablastModelInterface.php
@@ -1,8 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seablast\Seablast;
 
 use Seablast\Seablast\SeablastConfiguration;
+use Seablast\Seablast\Superglobals;
 use stdClass;
 
 /**
@@ -12,6 +15,6 @@ use stdClass;
  */
 interface SeablastModelInterface
 {
-    public function __construct(SeablastConfiguration $configuration);
-    public function getParameters(): stdClass;
+    public function __construct(SeablastConfiguration $configuration, Superglobals $superglobals);
+    public function knowledge(): stdClass;
 }

--- a/src/SeablastMysqli.php
+++ b/src/SeablastMysqli.php
@@ -19,7 +19,7 @@ class SeablastMysqli extends mysqli
     private $databaseError = false;
 
     /** @var string */
-    private $logPath = 'query_log.txt'; // TODO default is where??
+    private $logPath = APP_DIR . '/log/query_log.txt';
 
     /** @var string[] For Tracy Bar Panel. */
     private $statementList = [];
@@ -61,8 +61,8 @@ class SeablastMysqli extends mysqli
     {
         $trimmedQuery = trim($query);
         // todo what other keywords?
-        if (!$this->isSelectOrInfoQuery($trimmedQuery)) {
-            // Log the query if it doesn't start with SELECT or INFO
+        if (!$this->isSelectTypeQuery($trimmedQuery)) {
+            // Log queries that may change data
             // TODO jak NELOGOVAT hesla? Použít queryNoLog() nebo nějaká chytristika?
             $this->logQuery($query);
         }
@@ -74,9 +74,13 @@ class SeablastMysqli extends mysqli
         return $result;
     }
 
-    private function isSelectOrInfoQuery(string $query): bool
+    /**
+     * Identify query that doesn't change data
+     */
+    private function isSelectTypeQuery(string $query): bool
     {
-        return stripos($query, 'SELECT') === 0 || stripos($query, 'INFO') === 0;
+        return stripos($query, 'SELECT ') === 0 || stripos($query, 'SET ') === 0
+            || stripos($query, 'SHOW ') === 0;
     }
 
     /**

--- a/src/SeablastMysqli.php
+++ b/src/SeablastMysqli.php
@@ -59,7 +59,7 @@ class SeablastMysqli extends mysqli
     {
         $trimmedQuery = trim($query);
         // todo what other keywords?
-        if (!$this->isReafDataTypeQuery($trimmedQuery)) {
+        if (!$this->isReadDataTypeQuery($trimmedQuery)) {
             // Log queries that may change data
             // TODO jak NELOGOVAT hesla? Použít queryNoLog() nebo nějaká chytristika?
             $this->logQuery($query);

--- a/src/SeablastMysqli.php
+++ b/src/SeablastMysqli.php
@@ -33,8 +33,13 @@ class SeablastMysqli extends mysqli
         ?string $socket = null
     )
     {
-        // TODO if port/socket null, not call it at all
-        parent::__construct($host, $username, $password, $dbname, $port, $socket);
+        if (is_null($port)) {
+            parent::__construct($host, $username, $password, $dbname);
+        } elseif (is_null($socket)) {
+            parent::__construct($host, $username, $password, $dbname, $port);
+        } else {
+            parent::__construct($host, $username, $password, $dbname, $port, $socket);
+        }
     }
 
     public function query($query, $resultmode = MYSQLI_STORE_RESULT)
@@ -73,7 +78,7 @@ class SeablastMysqli extends mysqli
 
     public function showSqlBarPanel(): void
     {
-        if (empty($this->sqlStatementsArray)) {
+        if (empty($this->statementList)) {
             return;
         }
         $sqlBarPanel = new BarPanelTemplate('SQL: ' . count($this->statementList), $this->statementList);

--- a/src/SeablastMysqli.php
+++ b/src/SeablastMysqli.php
@@ -39,8 +39,7 @@ class SeablastMysqli extends mysqli
         string $dbname,
         ?int $port = null,
         ?string $socket = null
-    )
-    {
+    ) {
         if (is_null($port)) {
             parent::__construct($host, $username, $password, $dbname);
         } elseif (is_null($socket)) {
@@ -55,6 +54,12 @@ class SeablastMysqli extends mysqli
         }
     }
 
+    /**
+     *
+     * @param string $query
+     * @param int $resultmode
+     * @return bool|\mysqli_result
+     */
     public function query($query, $resultmode = MYSQLI_STORE_RESULT)
     {
         $trimmedQuery = trim($query);
@@ -77,8 +82,7 @@ class SeablastMysqli extends mysqli
      */
     private function isReadDataTypeQuery(string $query): bool
     {
-        return stripos($query, 'SELECT ') === 0 || stripos($query, 'SET ') === 0
-            || stripos($query, 'SHOW ') === 0;
+        return stripos($query, 'SELECT ') === 0 || stripos($query, 'SET ') === 0 || stripos($query, 'SHOW ') === 0;
     }
 
     /**
@@ -88,11 +92,15 @@ class SeablastMysqli extends mysqli
      */
     private function logQuery(string $query): void
     {
-        // TODO Implement your logging logic here
         // TODO add timestamp, rotating logs, error_log might be better
         file_put_contents($this->logPath, $query . PHP_EOL, FILE_APPEND);
     }
 
+    /**
+     * Show Tracy BarPanel with SQL statements.
+     *
+     * @return void
+     */
     public function showSqlBarPanel(): void
     {
         if (empty($this->statementList)) {

--- a/src/SeablastMysqli.php
+++ b/src/SeablastMysqli.php
@@ -17,10 +17,8 @@ class SeablastMysqli extends mysqli
 
     /** @var bool true if any of the SQL statements ended in an error state */
     private $databaseError = false;
-
     /** @var string */
-    private $logPath = APP_DIR . '/log/query_log.txt';
-
+    private $logPath = APP_DIR . '/log/query.log';
     /** @var string[] For Tracy Bar Panel. */
     private $statementList = [];
 
@@ -61,7 +59,7 @@ class SeablastMysqli extends mysqli
     {
         $trimmedQuery = trim($query);
         // todo what other keywords?
-        if (!$this->isSelectTypeQuery($trimmedQuery)) {
+        if (!$this->isReafDataTypeQuery($trimmedQuery)) {
             // Log queries that may change data
             // TODO jak NELOGOVAT hesla? Použít queryNoLog() nebo nějaká chytristika?
             $this->logQuery($query);
@@ -77,7 +75,7 @@ class SeablastMysqli extends mysqli
     /**
      * Identify query that doesn't change data
      */
-    private function isSelectTypeQuery(string $query): bool
+    private function isReadDataTypeQuery(string $query): bool
     {
         return stripos($query, 'SELECT ') === 0 || stripos($query, 'SET ') === 0
             || stripos($query, 'SHOW ') === 0;

--- a/src/SeablastMysqli.php
+++ b/src/SeablastMysqli.php
@@ -24,6 +24,16 @@ class SeablastMysqli extends mysqli
     /** @var string[] For Tracy Bar Panel. */
     private $statementList = [];
 
+    /**
+     *
+     * @param string $host
+     * @param string $username
+     * @param string $password
+     * @param string $dbname
+     * @param int|null $port
+     * @param string|null $socket
+     * @throws \Exception
+     */
     public function __construct(
         string $host,
         string $username,
@@ -39,6 +49,11 @@ class SeablastMysqli extends mysqli
             parent::__construct($host, $username, $password, $dbname, $port);
         } else {
             parent::__construct($host, $username, $password, $dbname, $port, $socket);
+        }
+        if ($this->connect_error) {
+            throw new \Exception(
+                'Connection to database failed with error #' . $this->connect_errno . ' ' . $this->connect_error
+            );
         }
     }
 

--- a/src/SeablastMysqli.php
+++ b/src/SeablastMysqli.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Seablast/Seablast;
+
+use mysqli;
+
+class SeablastMysqli extends mysqli
+{
+    //nette declaration
+
+    /** @var string */
+    private $logPath = 'query_log.txt'; // TODO default is where??
+    /** @var string[] For Tracy Bar Panel. */
+    private $statementList;
+
+    public function __construct($host, $username, $password, $dbname, $port = null, $socket = null) {
+        parent::__construct($host, $username, $password, $dbname, $port, $socket);
+        $this->set_charset("utf8"); // TODO viz configuration, ale jak to volat? Injection?
+        $this->statementList = [];
+    }
+
+    public function query($query, $resultmode = MYSQLI_STORE_RESULT) {
+        $trimmedQuery = trim($query);
+        $this->statementList[] = $trimmedQuery;
+        // todo what other keywords?
+        if (stripos($trimmedQuery, 'SELECT') !== 0 && stripos($trimmedQuery, 'INFO') !== 0) {
+            // Log the query if it doesn't start with SELECT or INFO
+            // TODO jak NELOGOVAT hesla? Použít queryNoLog() nebo nějaká chytristika?
+            $this->logQuery($query);
+        }
+        return parent::query($query, $resultmode);
+    }
+
+    private function logQuery($query) {
+        // Implement your logging logic here
+        file_put_contents($this->logPath, $query . PHP_EOL, FILE_APPEND);
+    }
+
+    public function showSqlBarPanel() {
+        // todo vrátit ten panel!
+        return $this->statementList;
+    }
+}

--- a/src/SeablastSetup.php
+++ b/src/SeablastSetup.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seablast\Seablast;
 
 //use Tracy\Debugger;

--- a/src/SeablastSetup.php
+++ b/src/SeablastSetup.php
@@ -4,11 +4,6 @@ declare(strict_types=1);
 
 namespace Seablast\Seablast;
 
-//use Tracy\Debugger;
-//use Tracy\ILogger;
-
-//use Webmozart\Assert\Assert;
-
 class SeablastSetup
 {
     use \Nette\SmartObject;

--- a/src/SeablastView.php
+++ b/src/SeablastView.php
@@ -14,7 +14,6 @@ class SeablastView
 
     /** @var SeablastModel */
     private $model;
-
     /** @var array<mixed>|stdClass TODO: only Object */
     private $params;
 
@@ -38,20 +37,22 @@ class SeablastView
             $this->params->configuration = $this->model->getConfiguration();
             $this->params->model = $this->model; // debug
         }
-        //echo ('<h1>Minimal model</h1>');
-        //var_dump($this->model); // minimal
-        // API
         if (isset($this->params->rest)) {
-            $this->renderJson($this->params->rest); // terminates
+            // API
+            $this->renderJson($this->params->rest);
+        } else {
+            // HTML UI
+            $this->renderLatte();
         }
-        // HTML UI
-        $this->renderLatte();
+        // TODO show BarPanel for User etc
+        $this->model->getConfiguration()->dbms()->showSqlBarPanel();
     }
 
     /**
      * Use app version of template, if unavailable use Seablast default version of template
      * If unavailable throw an Exception
      * @return string
+     * @throws \Exception
      */
     private function getTemplatePath(): string
     {
@@ -75,7 +76,7 @@ class SeablastView
      *
      * @param array<mixed>|object $data2json The data to be encoded as JSON.
      * @ param bool $htmlOutput if true, Tracy is displayed // TODO use FLAGS instead
-     * @return never Outputs JSON
+     * @return void Outputs JSON
      */
     private function renderJson(
         $data2json
@@ -86,7 +87,7 @@ class SeablastView
         header('Content-Type: application/json; charset=utf-8'); //the flag turns-off this line
         $result = json_encode($data2json);
         Assert::string($result);
-        exit($result);
+        echo($result);
     }
 
     /**

--- a/src/SeablastView.php
+++ b/src/SeablastView.php
@@ -2,9 +2,9 @@
 
 namespace Seablast\Seablast;
 
+use stdClass;
 use Tracy\Debugger;
-
-//use Webmozart\Assert\Assert;
+use Webmozart\Assert\Assert;
 
 class SeablastView
 {
@@ -13,15 +13,20 @@ class SeablastView
     /** @var SeablastModel */
     private $model;
 
-    /** @var array<mixed> TODO: Object */
+    /** @var array<mixed>|stdClass TODO: only Object */
     private $params;
 
+    /**
+     *
+     * @param \Seablast\Seablast\SeablastModel $model
+     * @return void
+     */
     public function __construct(SeablastModel $model)
     {
         $this->model = $model;
         Debugger::barDump($this->model, 'model');
         $this->params = $this->model->getParameters();
-        if (isArray($this->params) {
+        if (is_array($this->params)) {
             // array, current way - deprecated
             $this->params['configuration'] = $this->model->getConfiguration();
             $this->params['model'] = $this->model; // debug
@@ -33,8 +38,8 @@ class SeablastView
         //echo ('<h1>Minimal model</h1>');
         //var_dump($this->model); // minimal
         // API
-        if (isset($this->params->rest) {
-            $this->renderJson();
+        if (isset($this->params->rest)) {
+            $this->renderJson($this->params->rest);
             return;
         }
         // HTML UI
@@ -66,11 +71,14 @@ class SeablastView
     /**
      * Outputs the given data as JSON.
      *
-     * @param array|object $json The data to be encoded as JSON.
+     * @param array<mixed>|object $json The data to be encoded as JSON.
      */
-    private function renderJson($json) {
+    private function renderJson($json): string
+    {
         header('Content-Type: application/json; charset=utf-8');
-        echo json_encode($json);
+        $result = json_encode($json);
+        Assert::string($result);
+        return $result;
     }
 
     /**

--- a/src/SeablastView.php
+++ b/src/SeablastView.php
@@ -24,8 +24,9 @@ class SeablastView
     public function __construct(SeablastModel $model)
     {
         $this->model = $model;
-        Debugger::barDump($this->model, 'model');
+        Debugger::barDump($this->model, 'Model passed to SBView'); // debug
         $this->params = $this->model->getParameters();
+        Debugger::barDump($this->params, 'Params for SBView'); // debug
         if (is_array($this->params)) {
             // array, current way - deprecated
             $this->params['configuration'] = $this->model->getConfiguration();
@@ -71,14 +72,19 @@ class SeablastView
     /**
      * Outputs the given data as JSON.
      *
-     * @param array<mixed>|object $json The data to be encoded as JSON.
+     * @param array<mixed>|object $data2json The data to be encoded as JSON.
+     * @ param bool $htmlOutput if true, Tracy is displayed // TODO use FLAGS instead
+     * @return never Outputs JSON
      */
-    private function renderJson($json): string
+    private function renderJson(
+        $data2json
+        //, bool $htmlOutput = false
+    ): string
     {
-        header('Content-Type: application/json; charset=utf-8');
-        $result = json_encode($json);
+        header('Content-Type: application/json; charset=utf-8'); //the flag turns-off this line
+        $result = json_encode($data2json);
         Assert::string($result);
-        return $result;
+        exit($result);
     }
 
     /**

--- a/src/SeablastView.php
+++ b/src/SeablastView.php
@@ -45,7 +45,9 @@ class SeablastView
             $this->renderLatte();
         }
         // TODO show BarPanel for User etc
-        $this->model->getConfiguration()->dbms()->showSqlBarPanel();
+        if ($this->model->getConfiguration()->dbmsStatus()) {
+            $this->model->getConfiguration()->dbms()->showSqlBarPanel();
+        }
     }
 
     /**

--- a/src/SeablastView.php
+++ b/src/SeablastView.php
@@ -107,6 +107,7 @@ class SeablastView
     }
 
     /**
+     * Render selected latte template with the calculated parameters
      *
      * @return void
      */

--- a/src/SeablastView.php
+++ b/src/SeablastView.php
@@ -14,6 +14,7 @@ class SeablastView
 
     /** @var SeablastModel */
     private $model;
+
     /** @var array<mixed>|stdClass TODO: only Object */
     private $params;
 
@@ -51,11 +52,15 @@ class SeablastView
         if (isset($this->params->redirection)) {
             Assert::string($this->params->redirection->url);
             if (isset($this->params->redirection->httpCode)) {
-                Assert::inArray($this->params->redirection->httpCode, [301, 302, 303], 'Unauthorized redirect type %s');
+                Assert::inArray(
+                    $this->params->redirection->httpCode,
+                    [301, 302, 303],
+                    'Unauthorized redirect HTTP code %s'
+                );
             } else {
                 $this->params->redirection->httpCode = 301; // better for SEO than 303
             }
-            header("Location: {$this->params->redirection->url}", true, $this->params->redirections->httpCode);
+            header("Location: {$this->params->redirection->url}", true, $this->params->redirection->httpCode);
             header('Connection: close');
             $this->model->mapping['template'] = 'redirection';
             $this->renderLatte();
@@ -89,16 +94,13 @@ class SeablastView
      * Outputs the given data as JSON.
      *
      * @param array<mixed>|object $data2json The data to be encoded as JSON.
-     * @ param bool $htmlOutput if true, Tracy is displayed // TODO use FLAGS instead
      * @return void Outputs JSON
      */
-    private function renderJson(
-        $data2json
-        //, bool $htmlOutput = false
-    ): void
+    private function renderJson($data2json): void
     {
-        if(!$this->model->getConfiguration()->flag->status(SeablastConstant::FLAG_DEBUG_JSON));
-        header('Content-Type: application/json; charset=utf-8'); //the flag turns-off this line
+        if (!$this->model->getConfiguration()->flag->status(SeablastConstant::FLAG_DEBUG_JSON)) {
+            header('Content-Type: application/json; charset=utf-8'); //the flag turns-off this line
+        }
         $result = json_encode($data2json);
         Assert::string($result);
         echo($result);

--- a/src/SeablastView.php
+++ b/src/SeablastView.php
@@ -40,13 +40,38 @@ class SeablastView
         if (isset($this->params->rest)) {
             // API
             $this->renderJson($this->params->rest);
-        } else {
+        } elseif (!isset($this->params->redirection)) {
             // HTML UI
             $this->renderLatte();
         }
         // TODO show BarPanel for User etc
         if ($this->model->getConfiguration()->dbmsStatus()) {
             $this->model->getConfiguration()->dbms()->showSqlBarPanel();
+        }
+        if (isset($this->params->redirection)) {
+            Assert::string($this->params->redirection->url);
+            if (isset($this->params->redirection->httpCode)) {
+                Assert::inArray($this->httpCode, [301, 302, 303], 'Unauthorized redirect type %s');
+            } else {
+                $this->httpCode = 301; // better for SEO than 303
+            }
+            header("Location: {$redir}", true, $httpCode); // Note: for SEO 301 is much better than 303
+            header('Connection: close');
+            // todo mapping template redirection
+            /*
+            <!DOCTYPE html>
+<html>
+<head>
+    <title>Page Redirect</title>
+    <!-- Redirect to the specified URL after 5 seconds -->
+    <meta http-equiv="refresh" content="5;url=https://www.example.com">
+</head>
+<body>
+    <h1>Redirecting...</h1>
+    <p>You will be redirected in 5 seconds. If not, <a href="https://www.example.com">click here</a>.</p>
+</body>
+</html>
+            */
         }
     }
 

--- a/src/SeablastView.php
+++ b/src/SeablastView.php
@@ -51,27 +51,14 @@ class SeablastView
         if (isset($this->params->redirection)) {
             Assert::string($this->params->redirection->url);
             if (isset($this->params->redirection->httpCode)) {
-                Assert::inArray($this->httpCode, [301, 302, 303], 'Unauthorized redirect type %s');
+                Assert::inArray($this->params->redirection->httpCode, [301, 302, 303], 'Unauthorized redirect type %s');
             } else {
-                $this->httpCode = 301; // better for SEO than 303
+                $this->params->redirection->httpCode = 301; // better for SEO than 303
             }
-            header("Location: {$redir}", true, $httpCode); // Note: for SEO 301 is much better than 303
+            header("Location: {$this->params->redirection->url}", true, $this->params->redirections->httpCode);
             header('Connection: close');
-            // todo mapping template redirection
-            /*
-            <!DOCTYPE html>
-<html>
-<head>
-    <title>Page Redirect</title>
-    <!-- Redirect to the specified URL after 5 seconds -->
-    <meta http-equiv="refresh" content="5;url=https://www.example.com">
-</head>
-<body>
-    <h1>Redirecting...</h1>
-    <p>You will be redirected in 5 seconds. If not, <a href="https://www.example.com">click here</a>.</p>
-</body>
-</html>
-            */
+            $this->model->mapping['template'] = 'redirection';
+            $this->renderLatte();
         }
     }
 

--- a/src/SeablastView.php
+++ b/src/SeablastView.php
@@ -21,10 +21,23 @@ class SeablastView
         $this->model = $model;
         Debugger::barDump($this->model, 'model');
         $this->params = $this->model->getParameters();
-        $this->params['configuration'] = $this->model->getConfiguration();
-        $this->params['model'] = $this->model; // debug
+        if (isArray($this->params) {
+            // array, current way - deprecated
+            $this->params['configuration'] = $this->model->getConfiguration();
+            $this->params['model'] = $this->model; // debug
+        } else {
+            // object, the target way
+            $this->params->configuration = $this->model->getConfiguration();
+            $this->params->model = $this->model; // debug
+        }
         //echo ('<h1>Minimal model</h1>');
         //var_dump($this->model); // minimal
+        // API
+        if (isset($this->params->rest) {
+            $this->renderJson();
+            return;
+        }
+        // HTML UI
         $this->renderLatte();
     }
 
@@ -48,6 +61,16 @@ class SeablastView
         }
         throw new \Exception($this->model->mapping['template'] . ' template is neither in app ' . $templatePath
             . ' nor in library'); // TODO improve the error message
+    }
+
+    /**
+     * Outputs the given data as JSON.
+     *
+     * @param array|object $json The data to be encoded as JSON.
+     */
+    private function renderJson($json) {
+        header('Content-Type: application/json; charset=utf-8');
+        echo json_encode($json);
     }
 
     /**

--- a/src/SeablastView.php
+++ b/src/SeablastView.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seablast\Seablast;
 
 use stdClass;
@@ -40,8 +42,7 @@ class SeablastView
         //var_dump($this->model); // minimal
         // API
         if (isset($this->params->rest)) {
-            $this->renderJson($this->params->rest);
-            return;
+            $this->renderJson($this->params->rest); // terminates
         }
         // HTML UI
         $this->renderLatte();
@@ -79,8 +80,9 @@ class SeablastView
     private function renderJson(
         $data2json
         //, bool $htmlOutput = false
-    ): string
+    ): void
     {
+        if(!$this->model->getConfiguration()->flag->status(SeablastConstant::FLAG_DEBUG_JSON));
         header('Content-Type: application/json; charset=utf-8'); //the flag turns-off this line
         $result = json_encode($data2json);
         Assert::string($result);

--- a/src/Superglobals.php
+++ b/src/Superglobals.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Seablast\Seablast;
 
-//use Webmozart\Assert\Assert;
-
 class Superglobals
 {
     use \Nette\SmartObject;
@@ -28,7 +26,6 @@ class Superglobals
      */
     public function __construct(array $get = [], array $post = [], array $server = [], array $session = [])
     {
-        //todo named parameters? one array?
         $this->get = $get;
         $this->post = $post;
         $this->server = $server;

--- a/src/Superglobals.php
+++ b/src/Superglobals.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seablast\Seablast;
 
 //use Webmozart\Assert\Assert;

--- a/src/Tracy/BarPanelTemplate.php
+++ b/src/Tracy/BarPanelTemplate.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Seablast\Seablast\Tracy;
+
+use Tracy\IBarPanel;
+
+/**
+ * Tracy panel showing info about Template
+ *
+ */
+class BarPanelTemplate implements IBarPanel
+{
+    use \Nette\SmartObject;
+
+    /** @var string */
+    protected $tabTitle;
+    /** @var array<mixed> */
+    protected $panelDetails;
+    /** @var bool false = info, true = error */
+    protected $errorPanel = false;
+
+    /**
+     *
+     * @param string $tabTitle
+     * @param array<mixed> $panelDetails
+     */
+    public function __construct(string $tabTitle, array $panelDetails)
+    {
+        $this->tabTitle = $tabTitle;
+        $this->panelDetails = $panelDetails;
+    }
+
+    /**
+     * Renders HTML code for custom tab.
+     * @return string
+     */
+    public function getTab(): string
+    {
+        $style = $this->errorPanel ?
+            'display: block;background: #D51616;color: white;font-weight: bold;margin: -1px -.4em;padding: 1px .4em;' :
+            '';
+        $icon = ''; // Placeholder for icon implementation<img src="data:image/png;base64,<zakodovany obrazek>" />
+        $label = '<span class="tracy-label" style="' . $style . '">' . $this->tabTitle . '</span>';
+        return $icon . $label;
+    }
+
+    /**
+     * Renders HTML code for custom panel.
+     * @return string
+     */
+    public function getPanel(): string
+    {
+        $title = '<h1>' . htmlspecialchars($this->tabTitle) . '</h1>';
+        $cntTable = '';
+
+        foreach ($this->panelDetails as $id => $detail) {
+            $cntTable .= '<tr><td>' . htmlspecialchars($id) . '</td><td>';
+            if (is_array($detail)) {
+                $cntTable .= '<table>';
+                foreach ($detail as $k => $v) {
+                    $cntTable .= "<tr><td>" . htmlspecialchars($k) . "</td><td title='"
+                        . htmlspecialchars(print_r($v, true))
+                        . "'>" . htmlspecialchars(substr(print_r($v, true), 0, 240)) . "</td></tr>";
+                }
+                $cntTable .= '</table>';
+            } else {
+                $cntTable .= htmlspecialchars(print_r($detail, true));
+            }
+            $cntTable .= '</td></tr>';
+        }
+
+        $content = '<div class=\"tracy-inner tracy-InfoPanel\"><table><tbody>' .
+            $cntTable .
+            '</tbody></table>* Hover over field to see its full content.</div>';
+
+        return $title . $content;
+    }
+
+    /**
+     * Set panel to be displayed as error.
+     * If to be set to info again, try calling setError(false)
+     *
+     * @param bool $error OPTIONAL
+     * @return void
+     */
+    public function setError(bool $error = true): void
+    {
+        $this->errorPanel = (bool) $error;
+    }
+}

--- a/templates/redirection.latte
+++ b/templates/redirection.latte
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html>{* template expected by SeablastView for redirection *}
 <html>
     <head>
         <title>A Seablast app page redirect</title>

--- a/templates/redirection.latte
+++ b/templates/redirection.latte
@@ -1,0 +1,13 @@
+{* todo nice like under construction *}
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Page Redirect</title>
+    {* Redirect to the specified URL after 5 seconds *}
+    <meta http-equiv="refresh" content="5;url={$url}">
+</head>
+<body>
+    <h1>Redirecting...</h1>
+    <p>You will be redirected in 5 seconds. If not, <a href="{$url}">click here</a>.</p>
+</body>
+</html>

--- a/templates/redirection.latte
+++ b/templates/redirection.latte
@@ -4,7 +4,7 @@
         <title>A Seablast app page redirect</title>
         <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400&display=swap" rel="stylesheet">
         {* Redirect to the specified URL after 5 seconds *}
-        <meta http-equiv="refresh" content="5;url={$url}">
+        <meta http-equiv="refresh" content="5;url={$redirection->url}">
         <style>
             body {
                 font-family: 'Roboto', sans-serif;
@@ -41,7 +41,7 @@
     <body>
         <div class="container">
             <h1>Redirecting...</h1>
-            <p>You will be redirected in 5 seconds. If not, <a href="{$url}">click here</a>.</p>
+            <p>You will be redirected in 5 seconds. If not, <a href="{$redirection->url}">click here</a>.</p>
         </div>
     </body>
 </html>

--- a/templates/redirection.latte
+++ b/templates/redirection.latte
@@ -1,13 +1,47 @@
-{* todo nice like under construction *}
 <!DOCTYPE html>
 <html>
-<head>
-    <title>Page Redirect</title>
-    {* Redirect to the specified URL after 5 seconds *}
-    <meta http-equiv="refresh" content="5;url={$url}">
-</head>
-<body>
-    <h1>Redirecting...</h1>
-    <p>You will be redirected in 5 seconds. If not, <a href="{$url}">click here</a>.</p>
-</body>
+    <head>
+        <title>A Seablast app page redirect</title>
+        <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400&display=swap" rel="stylesheet">
+        {* Redirect to the specified URL after 5 seconds *}
+        <meta http-equiv="refresh" content="5;url={$url}">
+        <style>
+            body {
+                font-family: 'Roboto', sans-serif;
+                background-color: #f4f4f4;
+                margin: 0;
+                padding: 0;
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                height: 100vh;
+                color: #333;
+            }
+
+            .container {
+                text-align: center;
+                padding: 40px;
+                background: white;
+                box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+                border-radius: 10px;
+            }
+
+            h1 {
+                color: #007bff;
+                font-weight: 400;
+            }
+
+            p {
+                font-size: 18px;
+                font-weight: 300;
+                margin-top: 10px;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="container">
+            <h1>Redirecting...</h1>
+            <p>You will be redirected in 5 seconds. If not, <a href="{$url}">click here</a>.</p>
+        </div>
+    </body>
 </html>

--- a/under-construction.html
+++ b/under-construction.html
@@ -2,8 +2,44 @@
 <html>
     <head>
         <title>A Seablast app under construction</title>
+        <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400&display=swap" rel="stylesheet">
+        <style>
+            body {
+                font-family: 'Roboto', sans-serif;
+                background-color: #f4f4f4;
+                margin: 0;
+                padding: 0;
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                height: 100vh;
+                color: #333;
+            }
+
+            .container {
+                text-align: center;
+                padding: 40px;
+                background: white;
+                box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+                border-radius: 10px;
+            }
+
+            h1 {
+                color: #007bff;
+                font-weight: 400;
+            }
+
+            p {
+                font-size: 18px;
+                font-weight: 300;
+                margin-top: 10px;
+            }
+        </style>
     </head>
     <body>
-        Web app is under construction
+        <div class="container">
+            <h1>Under Construction</h1>
+            <p>The Seablast web app is currently under construction. We'll be back soon with an amazing experience!</p>
+        </div>
     </body>
 </html>


### PR DESCRIPTION
## Added
- GET parameters passed to model in configuration fields SB_GET_ARGUMENT_ID|SB_GET_ARGUMENT_CODE
- SeablastModelInterface.php to define minimal requirements for a model used by SeablastModel
- SeablastModel uses permanent argument Superglobals $superglobals (instead of injection `$m->setSuperglobals($superglobals);` if required by APP_MAPPING, so that it is always easily available)
- FLAG_DEBUG_JSON: Output JSON as HTML instead of application/json so that Tracy is displayed
- `declare(strict_types=1);` everywhere
- SB_WEB_FORCE_ASSET_VERSION Int to forced update of external CSS and JavaScript files
- SB_APP_ROOT_ABSOLUTE_URL The absolute URL of the root of the application
- show SQL statements in Tracy
- SeablastMysqli lazy initialisation; database load checked, if fails an Exception is thrown
- if Location redirection fails, a nice redirection HTML page ( redirection.latte ) is displayed
## Changed
- model->getParameters() -> model->knowledge()
- nice Under construction page