### PR TITLE
SeablastConstant::USER_ID and SeablastConstant::USER_GROUPS in SeablastConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### `Added` for new features
 - TableViewModel for admin.latte
-- table prefix (phinx) available through SB:phinx:table_prefix OR dbmsTablePrefix().
-- configuration contains SeablastConstant::USER_ID and SeablastConstant::USER_GROUPS
 
 ### `Changed` for changes in existing functionality
 
 ### `Deprecated` for soon-to-be removed features
 
 ### `Removed` for now removed features
-- SeablastConfiguration::optionsBool as redundant (use flag instead)
 
 ### `Fixed` for any bugfixes
 
 ### `Security` in case of vulnerabilities
+
+## [0.2.3] - 2024-03-03
+### Added
+- table prefix (phinx) available through SB:phinx:table_prefix OR dbmsTablePrefix()
+- configuration contains SeablastConstant::USER_ID and SeablastConstant::USER_GROUPS
+- SB_CHARSET_DATABASE to mysqli::set_charset
+- IdentityManagerInterface provides also user ID and list of groups
+
+### Removed
+- SeablastConfiguration::optionsBool as redundant (use flag instead)
 
 ## [0.2.2] - 2024-02-18
 ### Changed
@@ -96,7 +103,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - model returns knowledge()
 - a nice Under construction page
 
-[Unreleased]: https://github.com/WorkOfStan/seablast/compare/v0.2.2...HEAD
+[Unreleased]: https://github.com/WorkOfStan/seablast/compare/v0.2.3...HEAD
+[0.2.3]: https://github.com/WorkOfStan/seablast/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/WorkOfStan/seablast/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/WorkOfStan/seablast/compare/v0.2...v0.2.1
 [0.2]: https://github.com/WorkOfStan/seablast/compare/v0.1.1...v0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### `Added` for new features
 - TableViewModel for admin.latte
+- SB:phinx:table_prefix
 
 ### `Changed` for changes in existing functionality
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.3] - 2024-03-03
 ### Added
 - table prefix (phinx) available through SB:phinx:table_prefix OR dbmsTablePrefix()
-- configuration contains SeablastConstant::USER_ID and SeablastConstant::USER_GROUPS
+- SeablastConfiguration contains SeablastConstant::USER_ID and SeablastConstant::USER_GROUPS
 - SB_CHARSET_DATABASE to mysqli::set_charset
 - IdentityManagerInterface provides also user ID and list of groups
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - model returns knowledge()
 - a nice Under construction page
 
-[Unreleased]: https://github.com/WorkOfStan/seablast/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/WorkOfStan/seablast/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/WorkOfStan/seablast/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/WorkOfStan/seablast/compare/v0.2...v0.2.1
 [0.2]: https://github.com/WorkOfStan/seablast/compare/v0.1.1...v0.2
 [0.1.1]: https://github.com/WorkOfStan/seablast/compare/v0.1...v0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SB_CHARSET_DATABASE to mysqli::set_charset
 - IdentityManagerInterface provides also user ID and list of groups
 
+### Changed
+- using the documented double pipe `||` as a logical OR operator in composer.json (instead of the older single pipe operator)
+
 ### Removed
 - SeablastConfiguration::optionsBool as redundant (use flag instead)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Deprecated` for soon-to-be removed features
 
 ### `Removed` for now removed features
+- SeablastConfiguration::optionsBool as redundant (use flag instead)
 
 ### `Fixed` for any bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### `Added` for new features
 - TableViewModel for admin.latte
-- SB:phinx:table_prefix
+- table prefix (phinx) available through SB:phinx:table_prefix OR dbmsTablePrefix().
+- configuration contains SeablastConstant::USER_ID and SeablastConstant::USER_GROUPS
 
 ### `Changed` for changes in existing functionality
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The framework takes care of logs, database, multiple languages, user friendly HT
 ## Configuration
 - the default environment parameters are set in the [conf/default.conf.php](conf/default.conf.php)
 - everything can be overriden in the web app's `conf/app.conf.php` or even in its local deployment `conf/app.conf.local.php`
-- set the default phinx environment in the phinx configuration: ['environments']['default_environment']
+- set the default phinx environment in the phinx configuration: `['environments']['default_environment']`
 
 ## Model
 SeablastModel uses model field in APP_MAPPING to invoke the model in the App.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The framework takes care of logs, database, multiple languages, user friendly HT
 ## Configuration
 - the default environment parameters are set in the [conf/default.conf.php](conf/default.conf.php)
 - everything can be overriden in the web app's `conf/app.conf.php` or even in its local deployment `conf/app.conf.local.php`
+- set the default phinx environment in the phinx configuration: ['environments']['default_environment']
 
 ## Model
 SeablastModel uses model field in APP_MAPPING to invoke the model in the App.

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,8 @@ All planned changes to this project are documented in this file.
 
 ## Features
 - 240111, Messages from server and Ajax to user friendly closable banners; how to localize these messages - by some l10n?
-- 240119, APP_MAPPING restrictToGroups 1-admin, 2-contentAdmin, 3-user, other can be added in the app; check an open source logging library <https://github.com/hybridauth/hybridauth>
+- 240119, APP_MAPPING restrictToGroups 1-admin, 2-contentAdmin, 3-user, other can be added in the app (use constants instead of magic numbers)
+- 240119, check an open source social authentication library <https://github.com/hybridauth/hybridauth>
 
 ## UX
 - 231207, nice 404 (adapt redirection.latte to special operational pages layout)

--- a/composer.json
+++ b/composer.json
@@ -3,15 +3,15 @@
     "description": "Seablast for PHP - a minimalist MVC framework added by composer",
     "type": "library",
     "require": {
-        "php": "^7.2|^8.0",
+        "php": "^7.2 || ^8.0",
         "latte/latte": ">=2.4.6 <2.11.3",
-        "nette/utils": "^2.4.8|^3.2.2",
-        "symfony/security-csrf": "^4.4.37|^5|^6|^7",
+        "nette/utils": "^2.4.8 || ^3.2.2",
+        "symfony/security-csrf": "^4.4.37 || ^5 || ^6 || ^7",
         "tracy/tracy": "^2.4.10",
         "webmozart/assert": "^1.9.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4|^5|^6|^7|^8|^9|^10"
+        "phpunit/phpunit": "^4 || ^5 || ^6 || ^7 || ^8 || ^9 || ^10"
     },
     "license": "MIT",
     "authors": [

--- a/conf/default.conf.php
+++ b/conf/default.conf.php
@@ -31,6 +31,7 @@ return static function (SeablastConfiguration $SBConfig): void {
         ->setInt(SeablastConstant::SB_SETLOCALE_CATEGORY, LC_CTYPE)
         ->setString(SeablastConstant::SB_SETLOCALE_LOCALES, 'cs_CZ.UTF-8')
         ->setString(SeablastConstant::SB_ENCODING, 'UTF-8')
+        ->setString(SeablastConstant::SB_CHARSET_DATABASE, 'utf8')
         ->setString(SeablastConstant::SB_INI_SET_SESSION_USE_STRICT_MODE, '1')
         ->setString(SeablastConstant::SB_INI_SET_DISPLAY_ERRORS, '0') // errors only in the log; override locally
         ->setArrayString(SeablastConstant::DEBUG_IP_LIST, []) // default list with IPs to show Tracy

--- a/src/Exceptions/UploadException.php
+++ b/src/Exceptions/UploadException.php
@@ -25,8 +25,7 @@ class UploadException extends Exception
     use \Nette\SmartObject;
 
     /**
-     *
-     * @param int $code
+     * @param int $code of file upload error
      */
     public function __construct(int $code)
     {

--- a/src/IdentityManagerInterface.php
+++ b/src/IdentityManagerInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Seablast\Seablast;
 
 /**
- * The minimal interface for an IdentityManager
+ * The minimal interface for an IdentityManager.
  *
  * Usage: class IdentityManager implements IdentityManagerInterface
  */

--- a/src/IdentityManagerInterface.php
+++ b/src/IdentityManagerInterface.php
@@ -11,6 +11,28 @@ namespace Seablast\Seablast;
  */
 interface IdentityManagerInterface
 {
+    /**
+     * Return the list of groups to which user belong. It may be empty.
+     *
+     * @return int[]
+     */
+    public function getGroups(): array;
+    /**
+     * Return the id of user's role.
+     *
+     * @return int
+     */
     public function getRoleId(): int;
+    /**
+     * Return the user's id.
+     *
+     * @return int
+     */
+    public function getUserId(): int;
+    /**
+     * Determine whether the user is authenticated.
+     *
+     * @return bool
+     */
     public function isAuthenticated(): bool;
 }

--- a/src/Models/ErrorModel.php
+++ b/src/Models/ErrorModel.php
@@ -21,7 +21,6 @@ class ErrorModel implements SeablastModelInterface
     private $configuration;
 
     /**
-     *
      * @param SeablastConfiguration $configuration
      * @param Superglobals $superglobals
      * @throws \Exception
@@ -34,6 +33,7 @@ class ErrorModel implements SeablastModelInterface
 
     /**
      * Return the knowledge calculated in this model.
+     *
      * @return stdClass
      */
     public function knowledge(): stdClass

--- a/src/SeablastConfiguration.php
+++ b/src/SeablastConfiguration.php
@@ -18,6 +18,8 @@ class SeablastConfiguration
 
     /** @var ?SeablastMysqli */
     private $connection = null;
+    /** @var ?string */
+    private $connectionTablePrefix = null;
     /** @var SeablastFlag */
     public $flag;
     /** @var array<array<string[]>> */
@@ -76,8 +78,23 @@ class SeablastConfiguration
         );
         // todo does this really differentiate between successful connection, failed connection and no connection?
         Assert::isAOf($this->connection, '\Seablast\Seablast\SeablastMysqli');
-        $this->connection->set_charset('utf8'); // TODO viz configuration
-        $this->setString('SB:phinx:table_prefix', $phinx['environments'][$environment]['table_prefix'] ?? ''); // todo SBconstant
+        Assert::true($this->connection->set_charset($this->getString(>setString(SeablastConstant::SB_CHARSET_DATABASE))); // TODO viz configuration - check
+        $this->setString('SB:phinx:table_prefix', $phinx['environments'][$environment]['table_prefix'] ?? ''); // todo SBconstant or the following dbmsmethod?
+        $this->connectionTablePrefix = $phinx['environments'][$environment]['table_prefix'] ?? '';
+    }
+
+    /**
+     * Table prefix from phinx config
+     * TODO experimental - keep only if working well
+     *
+     * @return string
+     */
+    public function dbmsTablePrefix(): string
+    {
+        if(is_null($this->connectionTablePrefix)) {
+            throw new \Exception('Initiate db first.');
+        }
+        return $this->connectionTablePrefix;
     }
 
     /**

--- a/src/SeablastConfiguration.php
+++ b/src/SeablastConfiguration.php
@@ -52,6 +52,8 @@ class SeablastConfiguration
             Debugger::barDump('Creating database connection');
             $this->dbmsCreate();
         }
+        Assert::object($this->connection);
+        Assert::isAOf($this->connection, '\Seablast\Seablast\SeablastMysqli');
         return $this->connection;
     }
 
@@ -63,9 +65,9 @@ class SeablastConfiguration
     private function dbmsCreate(): void
     {
         $phinx = self::dbmsReadPhinx();
+        Assert::isArray($phinx['environments']);
         // todo Assert:: environment dle SB_phinx or default environment ... Parametry foreach Assert:: string
         $environment = $phinx['environments']['default_environment'] ?? 'development'; // todo check
-        Assert::isArray($phinx['environments']);
         Assert::keyExists($phinx['environments'], $environment, "Phinx environment `{$environment}` isn't defined");
         $port = isset($phinx['environments'][$environment]['port'])
             ? (int) $phinx['environments'][$environment]['port'] : null;
@@ -78,13 +80,16 @@ class SeablastConfiguration
         );
         // todo does this really differentiate between successful connection, failed connection and no connection?
         Assert::isAOf($this->connection, '\Seablast\Seablast\SeablastMysqli');
-        Assert::true($this->connection->set_charset($this->getString(>setString(SeablastConstant::SB_CHARSET_DATABASE))); // TODO viz configuration - check
-        $this->setString('SB:phinx:table_prefix', $phinx['environments'][$environment]['table_prefix'] ?? ''); // todo SBconstant or the following dbmsmethod?
+        // TODO viz configuration - check charset
+        Assert::true($this->connection->set_charset($this->getString(SeablastConstant::SB_CHARSET_DATABASE)));
+        // todo keep SBconstant or the $this->connectionTablePrefix accessible through dbmsmethod?
+        $this->setString('SB:phinx:table_prefix', $phinx['environments'][$environment]['table_prefix'] ?? '');
         $this->connectionTablePrefix = $phinx['environments'][$environment]['table_prefix'] ?? '';
     }
 
     /**
-     * Table prefix from phinx config
+     * Return the table prefix from phinx config.
+     *
      * TODO experimental - keep only if working well
      *
      * @return string
@@ -119,7 +124,7 @@ class SeablastConfiguration
      */
     public function dbmsStatus(): bool
     {
-        return is_a($this->connection, '\mysqli');
+        return is_object($this->connection) && is_a($this->connection, '\mysqli');
     }
 
     /**
@@ -257,7 +262,7 @@ class SeablastConfiguration
     {
         Assert::string($property);
         foreach ($value as $row) {
-            Assert::int($row);
+            Assert::integer($row);
         }
         $this->optionsArrayInt[$property] = $value;
         return $this;

--- a/src/SeablastConfiguration.php
+++ b/src/SeablastConfiguration.php
@@ -70,6 +70,7 @@ class SeablastConfiguration
         // todo does this really differentiate between successful connection, failed connection and no connection?
         Assert::isAOf($this->connection, '\Seablast\Seablast\SeablastMysqli');
         $this->connection->set_charset('utf8'); // TODO viz configuration
+        $this->setString('SB:phinx:table_prefix', $phinx['environments'][$environment]['table_prefix'] ?? ''); // todo SBconstant
     }
 
     /**

--- a/src/SeablastConfiguration.php
+++ b/src/SeablastConfiguration.php
@@ -19,6 +19,8 @@ class SeablastConfiguration
     public $flag;
     /** @var array<array<string[]>> */
     private $optionsArrayArrayString = [];
+    /** @var array<int[]> */
+    private $optionsArrayInt = [];
     /** @var array<string[]> */
     private $optionsArrayString = [];
     /** @ var bool[] */
@@ -108,6 +110,7 @@ class SeablastConfiguration
         Assert::string($property);
         $methods = [
             'getArrayArrayString',
+            'getArrayInt',
             'getArrayString',
             //'getBool',
             'getInt',
@@ -136,9 +139,23 @@ class SeablastConfiguration
     {
         Assert::string($property);
         if (!array_key_exists($property, $this->optionsArrayArrayString)) {
-            throw new SeablastConfigurationException('No array string for the property ' . $property);
+            throw new SeablastConfigurationException('No array of string array for the property ' . $property);
         }
         return $this->optionsArrayArrayString[$property];
+    }
+
+    /**
+     *
+     * @param string $property
+     * @return array<int>
+     */
+    public function getArrayInt(string $property): array
+    {
+        Assert::string($property);
+        if (!array_key_exists($property, $this->optionsArrayString)) {
+            throw new SeablastConfigurationException('No array int for the property ' . $property);
+        }
+        return $this->optionsArrayInt[$property];
     }
 
     /**
@@ -212,6 +229,22 @@ class SeablastConfiguration
             Assert::string($row);
         }
         $this->optionsArrayArrayString[$property][$key] = $value;
+        return $this;
+    }
+
+    /**
+     *
+     * @param string $property
+     * @param int[] $value
+     * @return $this
+     */
+    public function setArrayInt(string $property, array $value): self
+    {
+        Assert::string($property);
+        foreach ($value as $row) {
+            Assert::int($row);
+        }
+        $this->optionsArrayInt[$property] = $value;
         return $this;
     }
 

--- a/src/SeablastConfiguration.php
+++ b/src/SeablastConfiguration.php
@@ -66,8 +66,7 @@ class SeablastConfiguration
     {
         $phinx = self::dbmsReadPhinx();
         Assert::isArray($phinx['environments']);
-        // todo Assert:: environment dle SB_phinx or default environment ... Parametry foreach Assert:: string
-        $environment = $phinx['environments']['default_environment'] ?? 'development'; // todo check
+        $environment = $phinx['environments']['default_environment'] ?? 'development';
         Assert::keyExists($phinx['environments'], $environment, "Phinx environment `{$environment}` isn't defined");
         $port = isset($phinx['environments'][$environment]['port'])
             ? (int) $phinx['environments'][$environment]['port'] : null;
@@ -80,8 +79,10 @@ class SeablastConfiguration
         );
         // todo does this really differentiate between successful connection, failed connection and no connection?
         Assert::isAOf($this->connection, '\Seablast\Seablast\SeablastMysqli');
-        // TODO viz configuration - check charset
-        Assert::true($this->connection->set_charset($this->getString(SeablastConstant::SB_CHARSET_DATABASE)));
+        Assert::true(
+            $this->connection->set_charset($this->getString(SeablastConstant::SB_CHARSET_DATABASE)),
+            'Unexpected character set: ' . $this->getString(SeablastConstant::SB_CHARSET_DATABASE)
+        );
         // todo keep SBconstant or the $this->connectionTablePrefix accessible through dbmsmethod?
         $this->setString('SB:phinx:table_prefix', $phinx['environments'][$environment]['table_prefix'] ?? '');
         $this->connectionTablePrefix = $phinx['environments'][$environment]['table_prefix'] ?? '';
@@ -96,7 +97,7 @@ class SeablastConfiguration
      */
     public function dbmsTablePrefix(): string
     {
-        if(is_null($this->connectionTablePrefix)) {
+        if (is_null($this->connectionTablePrefix)) {
             throw new \Exception('Initiate db first.');
         }
         return $this->connectionTablePrefix;

--- a/src/SeablastConfiguration.php
+++ b/src/SeablastConfiguration.php
@@ -13,7 +13,7 @@ class SeablastConfiguration
 {
     use \Nette\SmartObject;
 
-    /** @var SeablastMysqli */
+    /** @var ?SeablastMysqli */
     private $connection = null;
     /** @var SeablastFlag */
     public $flag;
@@ -53,9 +53,9 @@ class SeablastConfiguration
      */
     private function dbmsCreate(): void
     {
-        $phinx = $this->dbmsReadPhinx();
+        $phinx = self::dbmsReadPhinx();
         // todo Assert:: environment dle SB_phinx or default environment ... Parametry foreach Assert:: string
-        $environment = 'development'; // todo config ?? $phinx['environments']['default_environment']
+        $environment = $phinx['environments']['default_environment'] ?? 'development'; // todo check
         Assert::isArray($phinx['environments']);
         Assert::keyExists($phinx['environments'], $environment, "Phinx environment `{$environment}` isn't defined");
         $port = isset($phinx['environments'][$environment]['port'])

--- a/src/SeablastConfiguration.php
+++ b/src/SeablastConfiguration.php
@@ -9,6 +9,9 @@ use Seablast\Seablast\SeablastMysqli;
 use Tracy\Debugger;
 use Webmozart\Assert\Assert;
 
+/**
+ * Universal data structure with strict data typing
+ */
 class SeablastConfiguration
 {
     use \Nette\SmartObject;
@@ -77,7 +80,6 @@ class SeablastConfiguration
 
     /**
      * Read the database connection parameters from an external phinx configuration
-     *
      * @return array<mixed>
      * @throws \Exception
      */
@@ -101,7 +103,6 @@ class SeablastConfiguration
 
     /**
      * Check existence of a property within configuration
-     *
      * @param string $property
      * @return bool
      */
@@ -131,7 +132,6 @@ class SeablastConfiguration
     }
 
     /**
-     *
      * @param string $property
      * @return array<array<string>>
      */
@@ -145,7 +145,6 @@ class SeablastConfiguration
     }
 
     /**
-     *
      * @param string $property
      * @return array<int>
      */
@@ -159,7 +158,6 @@ class SeablastConfiguration
     }
 
     /**
-     *
      * @param string $property
      * @return array<string>
      */
@@ -173,7 +171,6 @@ class SeablastConfiguration
     }
 
     /**
-     *
      * @param string $property
      * @return bool
      */
@@ -187,7 +184,6 @@ class SeablastConfiguration
     //}
 
     /**
-     *
      * @param string $property
      * @return int
      */
@@ -201,7 +197,6 @@ class SeablastConfiguration
     }
 
     /**
-     *
      * @param string $property
      * @return string
      */
@@ -215,7 +210,6 @@ class SeablastConfiguration
     }
 
     /**
-     *
      * @param string $property
      * @param string $key
      * @param string[] $value
@@ -233,7 +227,6 @@ class SeablastConfiguration
     }
 
     /**
-     *
      * @param string $property
      * @param int[] $value
      * @return $this
@@ -249,7 +242,6 @@ class SeablastConfiguration
     }
 
     /**
-     *
      * @param string $property
      * @param string[] $value
      * @return $this
@@ -265,7 +257,6 @@ class SeablastConfiguration
     }
 
     /**
-     *
      * @param string $property
      * @param bool $value
      * @return $this
@@ -279,7 +270,6 @@ class SeablastConfiguration
     //}
 
     /**
-     *
      * @param string $property
      * @param int $value
      * @return $this
@@ -293,7 +283,6 @@ class SeablastConfiguration
     }
 
     /**
-     *
      * @param string $property
      * @param string $value
      * @return $this

--- a/src/SeablastConfiguration.php
+++ b/src/SeablastConfiguration.php
@@ -10,7 +10,7 @@ use Tracy\Debugger;
 use Webmozart\Assert\Assert;
 
 /**
- * Universal data structure with strict data typing
+ * Universal data structure with strict data typing.
  */
 class SeablastConfiguration
 {
@@ -39,7 +39,8 @@ class SeablastConfiguration
     }
 
     /**
-     * Access to database with lazy initialisation
+     * Access to database with lazy initialisation.
+     *
      * @return SeablastMysqli
      */
     public function dbms(): SeablastMysqli
@@ -54,6 +55,7 @@ class SeablastConfiguration
 
     /**
      * Creates a database connection and sets up charset.
+     *
      * @return void
      */
     private function dbmsCreate(): void
@@ -79,7 +81,8 @@ class SeablastConfiguration
     }
 
     /**
-     * Read the database connection parameters from an external phinx configuration
+     * Read the database connection parameters from an external phinx configuration.
+     *
      * @return array<mixed>
      * @throws \Exception
      */
@@ -92,8 +95,9 @@ class SeablastConfiguration
     }
 
     /**
-     * Returns true on connected, false on not connected
-     * So that SQL Bar Panel is not requested in vain
+     * Returns true on connected, false on not connected:
+     * So that the SQL Bar Panel is not requested in vain.
+     *
      * @return bool
      */
     public function dbmsStatus(): bool
@@ -102,7 +106,8 @@ class SeablastConfiguration
     }
 
     /**
-     * Check existence of a property within configuration
+     * Check existence of a property within configuration.
+     *
      * @param string $property
      * @return bool
      */

--- a/src/SeablastConfiguration.php
+++ b/src/SeablastConfiguration.php
@@ -21,8 +21,8 @@ class SeablastConfiguration
     private $optionsArrayArrayString = [];
     /** @var array<string[]> */
     private $optionsArrayString = [];
-    /** @var bool[] */
-    private $optionsBool = [];
+    /** @ var bool[] */
+    //private $optionsBool = [];
     /** @var int[] */
     private $optionsInt = [];
     /** @var string[] */
@@ -109,7 +109,7 @@ class SeablastConfiguration
         $methods = [
             'getArrayArrayString',
             'getArrayString',
-            'getBool',
+            //'getBool',
             'getInt',
             'getString'
         ];
@@ -160,14 +160,14 @@ class SeablastConfiguration
      * @param string $property
      * @return bool
      */
-    public function getBool(string $property): bool
-    {
-        Assert::string($property);
-        if (!array_key_exists($property, $this->optionsBool)) {
-            throw new SeablastConfigurationException('No bool value for the property ' . $property);
-        }
-        return $this->optionsBool[$property];
-    }
+    //public function getBool(string $property): bool
+    //{
+    //    Assert::string($property);
+    //    if (!array_key_exists($property, $this->optionsBool)) {
+    //        throw new SeablastConfigurationException('No bool value for the property ' . $property);
+    //    }
+    //    return $this->optionsBool[$property];
+    //}
 
     /**
      *
@@ -237,13 +237,13 @@ class SeablastConfiguration
      * @param bool $value
      * @return $this
      */
-    public function setBool(string $property, bool $value): self
-    {
-        Assert::string($property);
-        Assert::boolean($value);
-        $this->optionsBool[$property] = $value;
-        return $this;
-    }
+    //public function setBool(string $property, bool $value): self
+    //{
+    //    Assert::string($property);
+    //    Assert::boolean($value);
+    //    $this->optionsBool[$property] = $value;
+    //    return $this;
+    //}
 
     /**
      *

--- a/src/SeablastConstant.php
+++ b/src/SeablastConstant.php
@@ -65,9 +65,9 @@ class SeablastConstant
     public const SB_INI_SET_DISPLAY_ERRORS = 'SB_INI_SET_DISPLAY_ERRORS';
     /**
      * TODO: make sure this is needed
-     * @var string $phinxEnvironment = 'development'; // use this phinx.yml environment for database connection
+     * @ var string $phinxEnvironment = 'development'; // use this phinx.yml environment for database connection
      */
-    public const SB_PHINX_ENVIRONMENT = 'SB_PHINX_ENVIRONMENT';
+    //TODO REMOVE public const SB_PHINX_ENVIRONMENT = 'SB_PHINX_ENVIRONMENT';
     /**
      * TODO: make sure this is needed
      * @var string

--- a/src/SeablastConstant.php
+++ b/src/SeablastConstant.php
@@ -51,6 +51,10 @@ class SeablastConstant
      */
     public const SB_ENCODING = 'SB_ENCODING';
     /**
+     * @var string mysqli::set_charset('utf8');
+     */
+    public const SB_CHARSET_DATABASE = 'SB_CHARSET_DATABASE';
+    /**
      * @var string ini_set('session.use_strict_mode', '1');
      */
     public const SB_INI_SET_SESSION_USE_STRICT_MODE = 'SB_INI_SET_SESSION_USE_STRICT_MODE';
@@ -145,7 +149,15 @@ class SeablastConstant
     /**
      * @var string int roleId
      */
+    public const USER_ID = 'SB:USER_ID';
+    /**
+     * @var string int roleId
+     */
     public const USER_ROLE_ID = 'SB:USER_ROLE_ID';
+    /**
+     * @var string int[] groupId
+     */
+    public const USER_GROUPS = 'SB:USER_GROUPS';
     /**
      * @var string int HTTP code
      */

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -37,7 +37,7 @@ class SeablastController
         // Wrapped _GET, _POST, _SESSION and _SERVER for sanitizing and testing
         $this->superglobals = $superglobals;
         $this->configuration = $configuration;
-        Debugger::barDump($this->configuration, 'Configuration at SBController start');
+        Debugger::barDump($this->configuration, 'Configuration at SeablastController start');
         $this->pageUnderConstruction();
         $this->applyConfiguration();
         $this->route();
@@ -178,11 +178,8 @@ class SeablastController
         );
         Assert::isArray($parsedUrl, 'MUST be an array with at least field `path`');
         Assert::keyExists($parsedUrl, 'path');
-        // so that /products and /products/ and /products/?id=1 are all resolved to /products
-        $this->uriPath = self::removeSuffix(
-            $parsedUrl['path'], // Outputs: /myapp/products
-            '/'
-        );
+        // /app/products and /app/products/ and /app/products/?id=1 are all resolved to /products
+        $this->uriPath = self::removeSuffix($parsedUrl['path'], '/');
         if (empty($this->uriPath)) {
             // so that the homepage has non empty path
             $this->uriPath = '/';
@@ -226,7 +223,7 @@ class SeablastController
         $this->uriPath = '/error';
         $mapping = $this->configuration->getArrayArrayString(SeablastConstant::APP_MAPPING);
         $this->mapping = $mapping[$this->uriPath];
-        // TODO - is there a more direct way than put it into configuration structure?
+        // TODO - is there a more direct way to propagate it to SBView than put it into configuration object?
         $this->configuration->setInt(SeablastConstant::ERROR_HTTP_CODE, $httpCode);
         $this->configuration->setString(SeablastConstant::ERROR_MESSAGE, $specificMessage);
     }

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -330,7 +330,10 @@ class SeablastController
         if ($this->configuration->exists(SeablastConstant::SB_IDENTITY_MANAGER)) {
             $identityManager = $this->configuration->getString(SeablastConstant::SB_IDENTITY_MANAGER);
             /* @phpstan-ignore-next-line Property $identity does not accept object. */
-            $this->identity = new $identityManager($this->configuration->dbms(), $this->configuration->dbmsTablePrefix());
+            $this->identity = new $identityManager($this->configuration->dbms());
+            if (method_exists($this->identity, 'setTablePrefix')) {
+                $this->identity->setTablePrefix($this->configuration->dbmsTablePrefix());
+            }
             // TODO consider decoupling dbms from identity
             Assert::methodExists($this->identity, 'isAuthenticated');
             if ($this->identity->isAuthenticated()) {

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -62,7 +62,7 @@ class SeablastController
             SeablastConstant::SB_ENCODING,
             SeablastConstant::SB_INI_SET_SESSION_USE_STRICT_MODE,
             SeablastConstant::SB_INI_SET_DISPLAY_ERRORS,
-            SeablastConstant::SB_PHINX_ENVIRONMENT,
+            //TODO: REMOVE: SeablastConstant::SB_PHINX_ENVIRONMENT,
             SeablastConstant::BACKYARD_LOGGING_LEVEL,
             //SeablastConstant::ADMIN_MAIL_ENABLED, // flag checked if ADMIN_MAIL_ADDRESS is populated
             SeablastConstant::ADMIN_MAIL_ADDRESS,
@@ -119,7 +119,7 @@ class SeablastController
                     case SeablastConstant::SB_INI_SET_DISPLAY_ERRORS:
                         ini_set('display_errors', $this->configuration->getString($property));
                         break;
-//                    case SeablastConstant::SB_PHINX_ENVIRONMENT:
+// TODO: REMOVE                    case SeablastConstant::SB_PHINX_ENVIRONMENT:
 //                        Debugger::barDump($property, 'not coded yet');
 //                        break;
 //                    case SeablastConstant::BACKYARD_LOGGING_LEVEL:
@@ -338,15 +338,13 @@ class SeablastController
             Assert::methodExists($this->identity, 'isAuthenticated');
             if ($this->identity->isAuthenticated()) {
                 $this->configuration->flag->activate(SeablastConstant::FLAG_USER_IS_AUTHENTICATED);
+                // Save the current user's role, id and group list into the configuration object
                 Assert::methodExists($this->identity, 'getRoleId');
                 Assert::methodExists($this->identity, 'getUserId');
                 Assert::methodExists($this->identity, 'getGroups');
-                // Save the current user's role into the configuration object
                 $this->configuration->setInt(SeablastConstant::USER_ROLE_ID, $this->identity->getRoleId());
                 $this->configuration->setInt(SeablastConstant::USER_ID, $this->identity->getUserId());
                 $this->configuration->setArrayInt(SeablastConstant::USER_GROUPS, $this->identity->getGroups());
-                // todo get user id
-                // todo get user groups
             }
         }
         // Authenticate: RBAC (Role-Based Access Control)

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -330,7 +330,7 @@ class SeablastController
         if ($this->configuration->exists(SeablastConstant::SB_IDENTITY_MANAGER)) {
             $identityManager = $this->configuration->getString(SeablastConstant::SB_IDENTITY_MANAGER);
             /* @phpstan-ignore-next-line Property $identity does not accept object. */
-            $this->identity = new $identityManager($this->configuration->dbms());
+            $this->identity = new $identityManager($this->configuration->dbms(), $this->configuration->dbmsTablePrefix());
             // TODO consider decoupling dbms from identity
             Assert::methodExists($this->identity, 'isAuthenticated');
             if ($this->identity->isAuthenticated()) {
@@ -338,6 +338,8 @@ class SeablastController
                 Assert::methodExists($this->identity, 'getRoleId');
                 // Save the current user's role into the configuration object
                 $this->configuration->setInt(SeablastConstant::USER_ROLE_ID, $this->identity->getRoleId());
+                // todo get user id
+                // todo get user groups
             }
         }
         // Authenticate: RBAC (Role-Based Access Control)

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -336,8 +336,12 @@ class SeablastController
             if ($this->identity->isAuthenticated()) {
                 $this->configuration->flag->activate(SeablastConstant::FLAG_USER_IS_AUTHENTICATED);
                 Assert::methodExists($this->identity, 'getRoleId');
+                Assert::methodExists($this->identity, 'getUserId');
+                Assert::methodExists($this->identity, 'getGroups');
                 // Save the current user's role into the configuration object
                 $this->configuration->setInt(SeablastConstant::USER_ROLE_ID, $this->identity->getRoleId());
+                $this->configuration->setInt(SeablastConstant::USER_ID, $this->identity->getUserId());
+                $this->configuration->setArrayInt(SeablastConstant::USER_GROUPS, $this->identity->getGroups());
                 // todo get user id
                 // todo get user groups
             }

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -44,8 +44,10 @@ class SeablastController
     }
 
     /**
-     * Apply the current configuration to the Seablast environment
-     * The settings not used here can still be used in Models
+     * Apply the current configuration to the Seablast environment.
+     *
+     * The settings not used here can still be used in Models.
+     *
      * @return void
      */
     private function applyConfiguration(): void
@@ -155,7 +157,8 @@ class SeablastController
     }
 
     /**
-     * Getter
+     * Getter.
+     *
      * @return SeablastConfiguration
      */
     public function getConfiguration(): SeablastConfiguration
@@ -164,7 +167,8 @@ class SeablastController
     }
 
     /**
-     * Transform URL from friendly URL etc. to a parametric address that may be further interpreted
+     * Transform URL from friendly URL etc. to a parametric address that may be further interpreted.
+     *
      * @param string $requestUri
      * @return void as uriPath and uriQuery are populated
      */
@@ -209,7 +213,8 @@ class SeablastController
     }
 
     /**
-     * Change mapping because there's an HTTP error (client side)
+     * Change mapping because there's an HTTP error (client side).
+     *
      * @param string $specificMessage that a user will see
      * @param int $httpCode
      * @return void
@@ -229,7 +234,8 @@ class SeablastController
     }
 
     /**
-     * Identify UNDER CONSTRUCTION situation and eventually return an UNDER CONSTRUCTION page
+     * Identify UNDER CONSTRUCTION situation and eventually return an UNDER CONSTRUCTION page.
+     *
      * @return void
      */
     private function pageUnderConstruction(): void
@@ -254,7 +260,7 @@ class SeablastController
     }
 
     /**
-     * If string start with prefix, remove it
+     * If string start with prefix, remove it.
      *
      * @param string $string
      * @param string $prefix
@@ -266,7 +272,7 @@ class SeablastController
     }
 
     /**
-     * If string ends with suffix, remove it
+     * If string ends with suffix, remove it.
      *
      * @param string $string
      * @param string $suffix
@@ -279,7 +285,8 @@ class SeablastController
     }
 
     /**
-     * Transform URI to model with parameters and RBAC
+     * Transform URI to model with parameters and RBAC.
+     *
      * @return void
      */
     private function route(): void
@@ -390,10 +397,13 @@ class SeablastController
     }
 
     /**
+     * Start session in the Seablast app.
+     *
      * Starting a session requires more complex initialization, so Tracy was started immediately
      * (so that it could handle any errors that occur).
      * Now initialize the session handler and
      * finally inform Tracy that the session is ready to be used using the dispatch() function.
+     *
      * @return void
      */
     private function startSession(): void

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -223,7 +223,7 @@ class SeablastController
         $this->uriPath = '/error';
         $mapping = $this->configuration->getArrayArrayString(SeablastConstant::APP_MAPPING);
         $this->mapping = $mapping[$this->uriPath];
-        // TODO - is there a more direct way to propagate it to SBView than put it into configuration object?
+        // TODO - is there a more direct way to propagate it to SeablastView than put it into configuration object?
         $this->configuration->setInt(SeablastConstant::ERROR_HTTP_CODE, $httpCode);
         $this->configuration->setString(SeablastConstant::ERROR_MESSAGE, $specificMessage);
     }
@@ -279,7 +279,7 @@ class SeablastController
     }
 
     /**
-     *
+     * Transform URI to model with parameters and RBAC
      * @return void
      */
     private function route(): void

--- a/src/SeablastModel.php
+++ b/src/SeablastModel.php
@@ -23,7 +23,6 @@ class SeablastModel
     private $viewParameters;
 
     /**
-     *
      * @param SeablastController $controller
      * @param Superglobals $superglobals
      */
@@ -48,7 +47,6 @@ class SeablastModel
     }
 
     /**
-     *
      * @return SeablastConfiguration
      */
     public function getConfiguration(): SeablastConfiguration
@@ -57,7 +55,8 @@ class SeablastModel
     }
 
     /**
-     * Parameters for Latte render (yes, Latte supports object even for PHP7.2 in 2.x latest)
+     * Parameters for Latte render (yes, Latte supports object even for PHP7.2 in 2.x latest).
+     *
      * @return stdClass
      */
     public function getParameters()

--- a/src/SeablastModel.php
+++ b/src/SeablastModel.php
@@ -62,10 +62,6 @@ class SeablastModel
      */
     public function getParameters()
     {
-        //if (is_null($this->viewParameters)) {
-        //    // no parameters
-        //    return [];
-        //}
         return $this->viewParameters;
     }
 }

--- a/src/SeablastModelInterface.php
+++ b/src/SeablastModelInterface.php
@@ -9,7 +9,7 @@ use Seablast\Seablast\Superglobals;
 use stdClass;
 
 /**
- * Definition of a model used by SeablastModel
+ * Definition of a model used by SeablastModel.
  *
  * Usage: class AbcModel implements SeablastModelInterface
  */

--- a/src/SeablastMysqli.php
+++ b/src/SeablastMysqli.php
@@ -24,7 +24,6 @@ class SeablastMysqli extends mysqli
     private $statementList = [];
 
     /**
-     *
      * @param string $host
      * @param string $username
      * @param string $password
@@ -56,6 +55,7 @@ class SeablastMysqli extends mysqli
     }
 
     /**
+     * Logging wrapper over performing a query on the database.
      *
      * @param string $query
      * @param int $resultmode
@@ -86,7 +86,10 @@ class SeablastMysqli extends mysqli
     }
 
     /**
-     * Identify query that doesn't change data
+     * Identify query that doesn't change data.
+     *
+     * @param string $query
+     * @return bool
      */
     private function isReadDataTypeQuery(string $query): bool
     {
@@ -94,6 +97,7 @@ class SeablastMysqli extends mysqli
     }
 
     /**
+     * Log this query.
      *
      * @param string $query
      * @return void

--- a/src/SeablastSetup.php
+++ b/src/SeablastSetup.php
@@ -26,7 +26,7 @@ class SeablastSetup
     }
 
     /**
-     *
+     * Getter
      * @return SeablastConfiguration
      */
     public function getConfiguration()
@@ -35,19 +35,15 @@ class SeablastSetup
     }
 
     /**
-     * Process a configuration file
+     * Process a configuration file, if it exists
      * @param string $configurationFilename
      * @return void
      */
     private function updateConfiguration(string $configurationFilename): void
     {
-        //Debugger::log('Trying config file: ' . $configurationFilename, ILogger::DEBUG);
-        if (!file_exists($configurationFilename)) {
-            // TODO make sure that with production settings, no INFO is written
-            //Debugger::log('Not existing config file: ' . $configurationFilename, ILogger::INFO);
-            return;
+        if (file_exists($configurationFilename)) {
+            $configurationClosure = require $configurationFilename;
+            $configurationClosure($this->configuration);
         }
-        $configurationClosure = require $configurationFilename;
-        $configurationClosure($this->configuration);
     }
 }

--- a/src/SeablastSetup.php
+++ b/src/SeablastSetup.php
@@ -26,7 +26,8 @@ class SeablastSetup
     }
 
     /**
-     * Getter
+     * Getter.
+     *
      * @return SeablastConfiguration
      */
     public function getConfiguration()
@@ -35,7 +36,8 @@ class SeablastSetup
     }
 
     /**
-     * Process a configuration file, if it exists
+     * Process a configuration file, if it exists.
+     *
      * @param string $configurationFilename
      * @return void
      */

--- a/src/SeablastView.php
+++ b/src/SeablastView.php
@@ -19,7 +19,6 @@ class SeablastView
     private $params;
 
     /**
-     *
      * @param \Seablast\Seablast\SeablastModel $model
      * @return void
      */
@@ -69,7 +68,8 @@ class SeablastView
     }
 
     /**
-     * If HTTP error code, show Tracy BarPanel
+     * If HTTP error code, show Tracy BarPanel.
+     *
      * @return void
      */
     private function showHttpErrorPanel(): void
@@ -87,8 +87,9 @@ class SeablastView
     }
 
     /**
-     * Use app version of template, if unavailable use Seablast default version of template
-     * If unavailable throw an Exception
+     * Use app version of template, if unavailable use Seablast default version of template,
+     * If unavailable throw an Exception.
+     *
      * @return string
      * @throws \Exception
      */
@@ -136,7 +137,7 @@ class SeablastView
     }
 
     /**
-     * Render selected latte template with the calculated parameters
+     * Render selected latte template with the calculated parameters.
      *
      * @return void
      */

--- a/src/Superglobals.php
+++ b/src/Superglobals.php
@@ -33,7 +33,7 @@ class Superglobals
     }
 
     /**
-     * Necessary in case of late session start
+     * Injection necessary in case of late session start
      * @param array<mixed> $session
      * @return void
      */

--- a/src/Superglobals.php
+++ b/src/Superglobals.php
@@ -18,7 +18,8 @@ class Superglobals
     public $session;
 
     /**
-     * May be setup either with superglobals for production or with arbitrary constants to test variants
+     * May be setup either with superglobals for production or with arbitrary constants to test variants.
+     *
      * @param array<mixed> $get
      * @param array<mixed> $post
      * @param array<mixed> $server
@@ -33,7 +34,8 @@ class Superglobals
     }
 
     /**
-     * Injection necessary in case of late session start
+     * Injection necessary in case of a late session start.
+     *
      * @param array<mixed> $session
      * @return void
      */


### PR DESCRIPTION
### Added
- table prefix (phinx) available through SB:phinx:table_prefix OR dbmsTablePrefix()
- configuration contains SeablastConstant::USER_ID and SeablastConstant::USER_GROUPS
- SB_CHARSET_DATABASE to mysqli::set_charset
- IdentityManagerInterface provides also user ID and list of groups

### Changed
- using the documented double pipe `||` as a logical OR operator in composer.json (instead of the older single pipe operator)

### Removed
- SeablastConfiguration::optionsBool as redundant (use flag instead)