### PR TITLE
Authenticate instead of 401

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - a nice Under construction page
 
 [Unreleased]: https://github.com/WorkOfStan/seablast/compare/v0.2.3.2...HEAD
-[0.2.3.1]: https://github.com/WorkOfStan/seablast/compare/v0.2.3.1...v0.2.3.2
+[0.2.3.2]: https://github.com/WorkOfStan/seablast/compare/v0.2.3.1...v0.2.3.2
 [0.2.3.1]: https://github.com/WorkOfStan/seablast/compare/v0.2.3...v0.2.3.1
 [0.2.3]: https://github.com/WorkOfStan/seablast/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/WorkOfStan/seablast/compare/v0.2.1...v0.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Security` in case of vulnerabilities
 
+## [0.2.3.2] - 2024-03-09
+### Added
+- SeablastConstant::APP_MAPPING_401 mapping to use in case of authentication required (instead of HTTP code 401)
+
 ## [0.2.3.1] - 2024-03-05
 ### Fixed
 - SeablastConfiguration::getArrayInt
@@ -110,7 +114,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - model returns knowledge()
 - a nice Under construction page
 
-[Unreleased]: https://github.com/WorkOfStan/seablast/compare/v0.2.3.1...HEAD
+[Unreleased]: https://github.com/WorkOfStan/seablast/compare/v0.2.3.2...HEAD
+[0.2.3.1]: https://github.com/WorkOfStan/seablast/compare/v0.2.3.1...v0.2.3.2
 [0.2.3.1]: https://github.com/WorkOfStan/seablast/compare/v0.2.3...v0.2.3.1
 [0.2.3]: https://github.com/WorkOfStan/seablast/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/WorkOfStan/seablast/compare/v0.2.1...v0.2.2

--- a/src/Apis/GenericRestApiJsonModel.php
+++ b/src/Apis/GenericRestApiJsonModel.php
@@ -38,7 +38,6 @@ class GenericRestApiJsonModel implements SeablastModelInterface
     protected $superglobals;
 
     /**
-     *
      * @param SeablastConfiguration $configuration
      * @param Superglobals $superglobals
      * @throws \Exception
@@ -60,7 +59,8 @@ class GenericRestApiJsonModel implements SeablastModelInterface
 
     /**
      * If the returned status >= 400, then it doesn't make sense to process anymore,
-     * but return the same status to SeablastView
+     * but return the same status to SeablastView.
+     *
      * @return stdClass
      */
     public function knowledge(): stdClass
@@ -86,8 +86,10 @@ class GenericRestApiJsonModel implements SeablastModelInterface
     }
 
     /**
-     * Validates standard PHP input
+     * Validates standard PHP input.
+     *
      * Doesn't output anything, even errors, because output is done by SeablastView which handles Tracy bar etc.
+     *
      * @return void
      */
     private function processInput(): void

--- a/src/SeablastConstant.php
+++ b/src/SeablastConstant.php
@@ -98,6 +98,10 @@ class SeablastConstant
      */
     public const APP_MAPPING = 'SB:APP_MAPPING';
     /**
+     * @var string string mapping to use in case of authentication required
+     */
+    public const APP_MAPPING_401 = 'SB:APP_MAPPING_401';
+    /**
      * @var string string with path to directory with Latte templates
      */
     public const LATTE_TEMPLATE = 'SB:LATTE_TEMPLATE';

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -354,6 +354,15 @@ class SeablastController
             }
             // Identity required, if not autheticated => 401
             if (!$this->configuration->flag->status(SeablastConstant::FLAG_USER_IS_AUTHENTICATED)) {
+                try {
+                    if (!empty($this->configuration->getString(SeablastConstant::APP_MAPPING_401))) {
+                        $mapping = $this->configuration->getArrayArrayString(SeablastConstant::APP_MAPPING);
+                        $this->mapping = $mapping[$this->configuration->getString(SeablastConstant::APP_MAPPING_401)];
+                        return;
+                    }
+                } catch (\Exception $ex) {
+                    Debugger::barDump($ex, 'No APP_MAPPING_401 to redirect for authentication');
+                }
                 $this->page40x('401 Unauthorized. Zalogujte se.', 401); // TODO 401 - seamless log in page
                 return;
             }

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -354,16 +354,17 @@ class SeablastController
             }
             // Identity required, if not autheticated => 401
             if (!$this->configuration->flag->status(SeablastConstant::FLAG_USER_IS_AUTHENTICATED)) {
-                try {
+                try { // Seamless log in page if prepared
                     if (!empty($this->configuration->getString(SeablastConstant::APP_MAPPING_401))) {
                         $mapping = $this->configuration->getArrayArrayString(SeablastConstant::APP_MAPPING);
                         $this->mapping = $mapping[$this->configuration->getString(SeablastConstant::APP_MAPPING_401)];
+                        // todo deeplink to the original place after login
                         return;
                     }
-                } catch (\Exception $ex) {
+                } catch (SeablastConfigurationException $ex) {
                     Debugger::barDump($ex, 'No APP_MAPPING_401 to redirect for authentication');
                 }
-                $this->page40x('401 Unauthorized. Zalogujte se.', 401); // TODO 401 - seamless log in page
+                $this->page40x('401 Unauthorized. Zalogujte se.', 401);
                 return;
             }
             Debugger::barDump('User is authenticated');

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -227,7 +227,7 @@ class SeablastController
         Debugger::barDump(['httpCode' => $httpCode, 'message' => $specificMessage], 'HTTP error');
         $this->uriPath = '/error';
         $mapping = $this->configuration->getArrayArrayString(SeablastConstant::APP_MAPPING);
-        $this->mapping = $mapping[$this->uriPath];
+        $this->mapping = $mapping[$this->uriPath]; // todo is it necessary to redefine uriPath? or just use it here
         // TODO - is there a more direct way to propagate it to SeablastView than put it into configuration object?
         $this->configuration->setInt(SeablastConstant::ERROR_HTTP_CODE, $httpCode);
         $this->configuration->setString(SeablastConstant::ERROR_MESSAGE, $specificMessage);

--- a/src/SeablastView.php
+++ b/src/SeablastView.php
@@ -95,7 +95,7 @@ class SeablastView
      */
     private function getTemplatePath(): string
     {
-        // todo - check file exists + inheritance
+        // check file exists + inheritance
         $templatePath = $this->model->getConfiguration()->getString(SeablastConstant::LATTE_TEMPLATE) . '/'
             . $this->model->mapping['template'] . '.latte';
         // APP


### PR DESCRIPTION
### Added
- SeablastConstant::APP_MAPPING_401 mapping to use in case of authentication required (instead of HTTP code 401)