### PR TITLE
Tracy logs through Seablast/logger, which provides verbosity control.

### DIFF
--- a/.github/workflows/php-composer-dependencies.yml
+++ b/.github/workflows/php-composer-dependencies.yml
@@ -21,5 +21,4 @@ jobs:
     uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@main
     with:
       # JSON
-      php-version: '["7.2", "7.3", "7.4"]'
-      #, "8.0", "8.1", "8.2", "8.3"]'
+      php-version: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]'

--- a/.github/workflows/php-composer-dependencies.yml
+++ b/.github/workflows/php-composer-dependencies.yml
@@ -21,4 +21,5 @@ jobs:
     uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@main
     with:
       # JSON
-      php-version: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]'
+      php-version: '["7.2", "7.3", "7.4"]'
+      #, "8.0", "8.1", "8.2", "8.3"]'

--- a/.htaccess
+++ b/.htaccess
@@ -1,10 +1,8 @@
 # If mod_alias is not enabled, the Apache should fail to show anything in order to always hide the files in the section below
 # nothing starting .git, i.e. also .github or .gitignore
 RedirectMatch 404 /\.git
-#TODO check phpstan.neon.dist below
 RedirectMatch 404 phpstan\.neon\.dist
 RedirectMatch 404 phpunit\.xml
-#RedirectMatch 404 \.gitignore #TODO check whether it is covered by /\.git above
 RedirectMatch 404 \.md$
 RedirectMatch 404 \.neon$
 RedirectMatch 404 \.sh$

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Security` in case of vulnerabilities
 
 ## [0.2.4] - 2024-08-04
+### Added
+- redirection HTTP code allows for 307 and 308
+
 ### Changed
 - use [seablast/logger](https://github.com/WorkOfStan/seablast-logger), a [PSR-3](https://www.php-fig.org/psr/psr-3/) compliant logger with verbosity control, as a logger for Tracy.
 - following SQL statements are not logged: DESCRIB, DO, EXPLAIN as they do not change the table data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,7 +152,8 @@ PHPUnit tests ready
 - model returns knowledge()
 - a nice Under construction page
 
-[Unreleased]: https://github.com/WorkOfStan/seablast/compare/v0.2.3.5...HEAD
+[Unreleased]: https://github.com/WorkOfStan/seablast/compare/v0.2.4...HEAD
+[0.2.4]: https://github.com/WorkOfStan/seablast/compare/v0.2.3.5...v0.2.4
 [0.2.3.5]: https://github.com/WorkOfStan/seablast/compare/v0.2.3.4...v0.2.3.5
 [0.2.3.4]: https://github.com/WorkOfStan/seablast/compare/v0.2.3.3...v0.2.3.4
 [0.2.3.3]: https://github.com/WorkOfStan/seablast/compare/v0.2.3.2...v0.2.3.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TableViewModel for admin.latte
 
 ### `Changed` for changes in existing functionality
+- use [seablast/logger](https://github.com/WorkOfStan/seablast-logger), a [PSR-3](https://www.php-fig.org/psr/psr-3/) compliant logger with verbosity control, as a logger for Tracy.
 
 ### `Deprecated` for soon-to-be removed features
 
 ### `Removed` for now removed features
 
 ### `Fixed` for any bugfixes
+- `.htaccess` checked
 
 ### `Security` in case of vulnerabilities
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TableViewModel for admin.latte
 
 ### `Changed` for changes in existing functionality
-- use [seablast/logger](https://github.com/WorkOfStan/seablast-logger), a [PSR-3](https://www.php-fig.org/psr/psr-3/) compliant logger with verbosity control, as a logger for Tracy.
 
 ### `Deprecated` for soon-to-be removed features
 
 ### `Removed` for now removed features
 
 ### `Fixed` for any bugfixes
-- `.htaccess` checked
 
 ### `Security` in case of vulnerabilities
+
+## [0.2.4] - 2024-08-04
+### Changed
+- use [seablast/logger](https://github.com/WorkOfStan/seablast-logger), a [PSR-3](https://www.php-fig.org/psr/psr-3/) compliant logger with verbosity control, as a logger for Tracy.
+- following SQL statements are not logged: DESCRIB, DO, EXPLAIN as they do not change the table data
+
+### Fixed
+- `.htaccess` checked
 
 ## [0.2.3.5] - 2024-06-09
 PHPUnit tests ready

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "latte/latte": ">=2.4.6 <2.11.3",
         "nette/utils": "^2.4.8 || ^3.2.2",
         "seablast/interfaces": "^0.1",
-        "seablast/logger": "^0.2",
+        "seablast/logger": "^2.0",
         "symfony/security-csrf": "^4.4.37 || ^5 || ^6 || ^7",
         "tracy/tracy": "^2.4.10",
         "webmozart/assert": "^1.9.1"

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "latte/latte": ">=2.4.6 <2.11.3",
         "nette/utils": "^2.4.8 || ^3.2.2",
         "seablast/interfaces": "^0.1",
-        "seablast/logger": "dev-feature/refactoring2407",
+        "seablast/logger": "^0.1",
         "symfony/security-csrf": "^4.4.37 || ^5 || ^6 || ^7",
         "tracy/tracy": "^2.4.10",
         "webmozart/assert": "^1.9.1"

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "latte/latte": ">=2.4.6 <2.11.3",
         "nette/utils": "^2.4.8 || ^3.2.2",
         "seablast/interfaces": "^0.1",
-        "seablast/logger": "^0.1",
+        "seablast/logger": "^0.2",
         "symfony/security-csrf": "^4.4.37 || ^5 || ^6 || ^7",
         "tracy/tracy": "^2.4.10",
         "webmozart/assert": "^1.9.1"

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "latte/latte": ">=2.4.6 <2.11.3",
         "nette/utils": "^2.4.8 || ^3.2.2",
         "seablast/interfaces": "^0.1",
-        "seablast/logger": "^0.1",
+        "seablast/logger": "dev-feature/refactoring2407",
         "symfony/security-csrf": "^4.4.37 || ^5 || ^6 || ^7",
         "tracy/tracy": "^2.4.10",
         "webmozart/assert": "^1.9.1"

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "latte/latte": ">=2.4.6 <2.11.3",
         "nette/utils": "^2.4.8 || ^3.2.2",
         "seablast/interfaces": "^0.1",
+        "seablast/logger": "^0.1",
         "symfony/security-csrf": "^4.4.37 || ^5 || ^6 || ^7",
         "tracy/tracy": "^2.4.10",
         "webmozart/assert": "^1.9.1"

--- a/conf/default.conf.php
+++ b/conf/default.conf.php
@@ -11,18 +11,11 @@ use Seablast\Seablast\SeablastConstant;
 return static function (SeablastConfiguration $SBConfig): void {
     $SBConfig->flag
         ->activate(SeablastConstant::FLAG_WEB_RUNNING) // debug
-        //->activate('as') // debug
-        //->deactivate('mon') // debug
         ->deactivate(SeablastConstant::ADMIN_MAIL_ENABLED) // default is not sending emails to admin
         ->deactivate(SeablastConstant::USER_MAIL_ENABLED) // default is not sending emails to users
         //->activate(SeablastConstant::FLAG_DEBUG_JSON) // JSON would be displayed directly with Tracy
     ;
     $SBConfig
-        // Debug
-        //->setInt('a', 23)
-        //->setInt('b', 45)
-        //->setString('test-string', 'default-value') // debug
-        //->setArrayString('test-array-string', ['a', 'y', 'omega'])
         // Environment
         ->setInt(SeablastConstant::SB_ERROR_REPORTING, E_ALL & ~E_NOTICE)
         ->setInt(SeablastConstant::SB_SESSION_SET_COOKIE_LIFETIME, 60 * 60 * 24 * 2) // 2 days
@@ -35,6 +28,7 @@ return static function (SeablastConfiguration $SBConfig): void {
         ->setString(SeablastConstant::SB_INI_SET_SESSION_USE_STRICT_MODE, '1')
         ->setString(SeablastConstant::SB_INI_SET_DISPLAY_ERRORS, '0') // errors only in the log; override locally
         ->setArrayString(SeablastConstant::DEBUG_IP_LIST, []) // default list with IPs to show Tracy
+        ->setInt(SeablastConstant::SB_LOGGING_LEVEL, 3) // log warnings and more severe events
         // Database
         // Does not have to be 'testing' expected by the automatic GitHub tests as environment is set in the unit tests
         // like this: `$setup->getConfiguration()->setString(SeablastConstant::SB_PHINX_ENVIRONMENT, 'testing');`
@@ -42,7 +36,7 @@ return static function (SeablastConfiguration $SBConfig): void {
         // Latte templates
         ->setString(SeablastConstant::LATTE_TEMPLATE, 'views')
         ->setString(SeablastConstant::LATTE_CACHE, APP_DIR . '/cache')
-        // Error API is always available if not overriden
+        // Error API is always available (if not overriden)
         ->setArrayArrayString(
             SeablastConstant::APP_MAPPING,
             '/api/error', // todo demonstrate in SB-dist
@@ -50,7 +44,7 @@ return static function (SeablastConfiguration $SBConfig): void {
                 'model' => '\Seablast\Seablast\Apis\ApiErrorModel',
             ]
         )
-        // Error page is always available if not overriden
+        // Error page is always available (if not overriden)
         ->setArrayArrayString(
             SeablastConstant::APP_MAPPING,
             '/error', // todo demonstrate in SB-dist

--- a/index.php
+++ b/index.php
@@ -1,8 +1,6 @@
 <?php
 
-// Load Composer contents for the app if this library is called from within the app
-require_once __DIR__ . '/defineAppDir.php';
-require_once APP_DIR . '/vendor/autoload.php';
+declare(strict_types=1);
 
 use Seablast\Seablast\SeablastConstant;
 use Seablast\Seablast\SeablastController;
@@ -11,6 +9,10 @@ use Seablast\Seablast\SeablastSetup;
 use Seablast\Seablast\SeablastView;
 use Seablast\Seablast\Superglobals;
 use Tracy\Debugger;
+
+// Load Composer contents for the app if this library is called from within the app
+require_once __DIR__ . '/defineAppDir.php';
+require_once APP_DIR . '/vendor/autoload.php';
 
 //Tracy is able to show Debug bar and Bluescreens for Ajax and redirected requests.
 //You just have to start session before Tracy

--- a/src/SeablastConstant.php
+++ b/src/SeablastConstant.php
@@ -68,10 +68,9 @@ class SeablastConstant
      */
     public const SB_PHINX_ENVIRONMENT = 'SB_PHINX_ENVIRONMENT';
     /**
-     * TODO: make sure this is needed
-     * @var string
+     * @var string trigger and verbosity control for seablast/logger
      */
-    public const BACKYARD_LOGGING_LEVEL = 'SB:BACKYARD_LOGGING_LEVEL';
+    public const SB_LOGGING_LEVEL = 'SB:SB_LOGGING_LEVEL';
     /**
      * @var string flag whether to send emails to admin
      */

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -142,7 +142,7 @@ class SeablastController
                         ini_set('display_errors', $this->configuration->getString($property));
                         break;
                     case SeablastConstant::SB_LOGGING_LEVEL:
-                        $logger = new \Seablast\Logger\Logger(['logging_level' => $this->configuration->getString($property))]);
+                        $logger = new \Seablast\Logger\Logger(['logging_level' => $this->configuration->getString($property)]);
                         $this->tracyLogger = new \Tracy\Bridges\Psr\PsrToTracyLoggerAdapter($logger);
                         // todo inject admin_email; mail_for_admim null not false!!
                         // todo di of user/log level later - does it change anything?

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -390,7 +390,9 @@ class SeablastController
                 $this->configuration->setInt(SeablastConstant::USER_ROLE_ID, $this->identity->getRoleId());
                 $this->configuration->setInt(SeablastConstant::USER_ID, $this->identity->getUserId());
                 $this->configuration->setArrayInt(SeablastConstant::USER_GROUPS, $this->identity->getGroups());
-                $this->logger->setUser($this->identity->getUserId());
+                if (!is_null($this->logger)) {
+                    $this->logger->setUser($this->identity->getUserId());
+                }
             }
         }
         // Authenticate: RBAC (Role-Based Access Control)

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -25,6 +25,8 @@ class SeablastController
     private $scriptName;
     /** @var Superglobals */
     private $superglobals;
+    /** @var ?\Tracy\ILogger */
+    private $tracyLogger = null;
     /** @var string */
     private $uriPath = '';
     /** @var string */
@@ -79,6 +81,14 @@ class SeablastController
             SeablastConstant::ADMIN_MAIL_ADDRESS,
             //SeablastConstant::DEBUG_IP_LIST, // already used in index.php
         ];
+
+        $logger = new Seablast\Logger\Logger();
+        $this->tracyLogger = new Tracy\Bridges\Psr\PsrToTracyLoggerAdapter($logger);
+        //Debugger::setLogger($tracyLogger);
+        //Debugger::enable();
+        // todo move into backyardLoggingLevel and inject admin_email; mail_for_admim null not false!!
+        // todo di of user/log level later - does it change anything?
+
         foreach ($configurationOrder as $property) {
             if ($this->configuration->exists($property)) {
                 switch ($property) {
@@ -456,6 +466,9 @@ class SeablastController
     private function startSession(): void
     {
         session_start() || error_log('session_start failed');
+        if (!is_null($tracyLogger)) {
+            Debugger::setLogger($this->tracyLogger);
+        }
         Debugger::dispatch();
         $this->superglobals->setSession($_SESSION); // as only now the session started
     }

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -82,8 +82,8 @@ class SeablastController
             //SeablastConstant::DEBUG_IP_LIST, // already used in index.php
         ];
 
-        $logger = new Seablast\Logger\Logger();
-        $this->tracyLogger = new Tracy\Bridges\Psr\PsrToTracyLoggerAdapter($logger);
+        $logger = new \Seablast\Logger\Logger();
+        $this->tracyLogger = new \Tracy\Bridges\Psr\PsrToTracyLoggerAdapter($logger);
         //Debugger::setLogger($tracyLogger);
         //Debugger::enable();
         // todo move into backyardLoggingLevel and inject admin_email; mail_for_admim null not false!!
@@ -466,7 +466,7 @@ class SeablastController
     private function startSession(): void
     {
         session_start() || error_log('session_start failed');
-        if (!is_null($tracyLogger)) {
+        if (!is_null($this->tracyLogger)) {
             Debugger::setLogger($this->tracyLogger);
         }
         Debugger::dispatch();

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -78,9 +78,8 @@ class SeablastController
             SeablastConstant::SB_INI_SET_SESSION_USE_STRICT_MODE,
             SeablastConstant::SB_INI_SET_DISPLAY_ERRORS,
             SeablastConstant::SB_LOGGING_LEVEL,
-            //SeablastConstant::ADMIN_MAIL_ENABLED, // flag checked if ADMIN_MAIL_ADDRESS is populated
-            // todo describe both above
-            SeablastConstant::ADMIN_MAIL_ADDRESS,
+            //SeablastConstant::ADMIN_MAIL_ENABLED, // activate flag if ADMIN_MAIL_ADDRESS is populated
+            SeablastConstant::ADMIN_MAIL_ADDRESS, // used if ADMIN_MAIL_ENABLED activated
             //SeablastConstant::DEBUG_IP_LIST, // already used in index.php
         ];
         foreach ($configurationOrder as $property) {
@@ -176,7 +175,7 @@ class SeablastController
             SeablastConstant::SB_APP_ROOT_ABSOLUTE_URL,
             'http' . ($isHttps ? 's' : '') . '://' .
             $this->superglobals->server['HTTP_HOST'] .
-            $this->removeSuffix($this->scriptName, '/vendor/seablast/seablast/index.php') 
+            $this->removeSuffix($this->scriptName, '/vendor/seablast/seablast/index.php')
         );
     }
 

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -83,14 +83,6 @@ class SeablastController
             SeablastConstant::ADMIN_MAIL_ADDRESS,
             //SeablastConstant::DEBUG_IP_LIST, // already used in index.php
         ];
-
-        $logger = new \Seablast\Logger\Logger();
-        $this->tracyLogger = new \Tracy\Bridges\Psr\PsrToTracyLoggerAdapter($logger);
-        //Debugger::setLogger($tracyLogger);
-        //Debugger::enable();
-        // todo move into backyardLoggingLevel and inject admin_email; mail_for_admim null not false!!
-        // todo di of user/log level later - does it change anything?
-
         foreach ($configurationOrder as $property) {
             if ($this->configuration->exists($property)) {
                 switch ($property) {
@@ -144,10 +136,10 @@ class SeablastController
                         break;
                     case SeablastConstant::SB_LOGGING_LEVEL:
                         $logger = new \Seablast\Logger\Logger([
-                                'logging_level' => $this->configuration->getString($property),
+                                'logging_level' => $this->configuration->getInt($property),
                         ]);
                         $this->tracyLogger = new \Tracy\Bridges\Psr\PsrToTracyLoggerAdapter($logger);
-                        // todo inject admin_email; mail_for_admim null not false!!
+                        // todo inject admin_email; mail_for_admin null not false!!
                         // todo di of user/log level later - does it change anything?
                         break;
                     case SeablastConstant::ADMIN_MAIL_ADDRESS:
@@ -180,13 +172,11 @@ class SeablastController
             (!empty($this->superglobals->server['HTTPS']) && $this->superglobals->server['HTTPS'] == 'on') ||
             (!empty($this->superglobals->server['SERVER_PORT']) && $this->superglobals->server['SERVER_PORT'] == '443');
         $this->configuration->setString(
+            // Note: without trailing slash even for app root in domain root, i.e. https://www.service.com
             SeablastConstant::SB_APP_ROOT_ABSOLUTE_URL,
             'http' . ($isHttps ? 's' : '') . '://' .
             $this->superglobals->server['HTTP_HOST'] .
-            $this->removeSuffix(
-                $this->scriptName,
-                '/vendor/seablast/seablast/index.php'
-            ) // Note: without trailing slash even for app root in domain root, i.e. https://www.service.com
+            $this->removeSuffix($this->scriptName, '/vendor/seablast/seablast/index.php') 
         );
     }
 

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -76,8 +76,9 @@ class SeablastController
             SeablastConstant::SB_ENCODING,
             SeablastConstant::SB_INI_SET_SESSION_USE_STRICT_MODE,
             SeablastConstant::SB_INI_SET_DISPLAY_ERRORS,
-            SeablastConstant::BACKYARD_LOGGING_LEVEL,
+            SeablastConstant::SB_LOGGING_LEVEL,
             //SeablastConstant::ADMIN_MAIL_ENABLED, // flag checked if ADMIN_MAIL_ADDRESS is populated
+            // todo describe both above
             SeablastConstant::ADMIN_MAIL_ADDRESS,
             //SeablastConstant::DEBUG_IP_LIST, // already used in index.php
         ];
@@ -140,9 +141,12 @@ class SeablastController
                     case SeablastConstant::SB_INI_SET_DISPLAY_ERRORS:
                         ini_set('display_errors', $this->configuration->getString($property));
                         break;
-//                    case SeablastConstant::BACKYARD_LOGGING_LEVEL:
-//                        Debugger::barDump($property, 'not coded yet');
-//                        break;
+                    case SeablastConstant::SB_LOGGING_LEVEL:
+                        $logger = new \Seablast\Logger\Logger(['logging_level' => $this->configuration->getString($property))]);
+                        $this->tracyLogger = new \Tracy\Bridges\Psr\PsrToTracyLoggerAdapter($logger);
+                        // todo inject admin_email; mail_for_admim null not false!!
+                        // todo di of user/log level later - does it change anything?
+                        break;
                     case SeablastConstant::ADMIN_MAIL_ADDRESS:
                         if ($this->configuration->flag->status(SeablastConstant::ADMIN_MAIL_ENABLED)) {
                             // set here the admin email address to all debug tools

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -136,6 +136,12 @@ class SeablastController
                     case SeablastConstant::SB_LOGGING_LEVEL:
                         $logger = new \Seablast\Logger\Logger([
                                 'logging_level' => $this->configuration->getInt($property),
+                                'error_log_message_type' => 3,
+                                'logging_file' => APP_DIR . '/log/seablast',
+                                'mail_for_admin_enabled' => ((
+                                    $this->configuration->flag->status(SeablastConstant::ADMIN_MAIL_ENABLED)
+                                    && $this->configuration->exists(SeablastConstant::ADMIN_MAIL_ADDRESS)
+                                ) ? $this->configuration->getString(SeablastConstant::ADMIN_MAIL_ADDRESS) : false),
                         ]);
                         $this->tracyLogger = new \Tracy\Bridges\Psr\PsrToTracyLoggerAdapter($logger);
                         // todo inject admin_email; mail_for_admin null not false!!

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -9,6 +9,7 @@ use Seablast\Seablast\Exceptions\ClientErrorException;
 use Seablast\Seablast\SeablastConfiguration;
 use Seablast\Seablast\Superglobals;
 use Tracy\Debugger;
+use Tracy\ILogger;
 use Webmozart\Assert\Assert;
 
 class SeablastController
@@ -25,7 +26,7 @@ class SeablastController
     private $scriptName;
     /** @var Superglobals */
     private $superglobals;
-    /** @var ?\Tracy\ILogger */
+    /** @var ?ILogger */
     private $tracyLogger = null;
     /** @var string */
     private $uriPath = '';
@@ -50,7 +51,7 @@ class SeablastController
         } else {
             Debugger::log(
                 'Session already started: not invoking applyConfigurationBeforeSession by ' . $_SERVER['PHP_SELF'],
-                \Tracy\ILogger::INFO
+                ILogger::INFO
             );
         }
         $this->applyConfigurationWithSession();
@@ -142,7 +143,9 @@ class SeablastController
                         ini_set('display_errors', $this->configuration->getString($property));
                         break;
                     case SeablastConstant::SB_LOGGING_LEVEL:
-                        $logger = new \Seablast\Logger\Logger(['logging_level' => $this->configuration->getString($property)]);
+                        $logger = new \Seablast\Logger\Logger([
+                                'logging_level' => $this->configuration->getString($property),
+                        ]);
                         $this->tracyLogger = new \Tracy\Bridges\Psr\PsrToTracyLoggerAdapter($logger);
                         // todo inject admin_email; mail_for_admim null not false!!
                         // todo di of user/log level later - does it change anything?

--- a/src/SeablastMysqli.php
+++ b/src/SeablastMysqli.php
@@ -68,7 +68,6 @@ class SeablastMysqli extends mysqli
     public function query($query, $resultmode = MYSQLI_STORE_RESULT)
     {
         $trimmedQuery = trim($query);
-        // todo what other keywords?
         if (!$this->isReadDataTypeQuery($trimmedQuery)) {
             // Log queries that may change data
             // TODO jak NELOGOVAT hesla? Použít queryNoLog() nebo nějaká chytristika?
@@ -115,7 +114,8 @@ class SeablastMysqli extends mysqli
      */
     private function isReadDataTypeQuery(string $query): bool
     {
-        return stripos($query, 'SELECT ') === 0 || stripos($query, 'SET ') === 0 || stripos($query, 'SHOW ') === 0;
+        return stripos($query, 'SELECT ') === 0 || stripos($query, 'SET ') === 0 || stripos($query, 'SHOW ') === 0
+            || stripos($query, 'DESCRIBE ') === 0 || stripos($query, 'DO ') === 0 || stripos($query, 'EXPLAIN ') === 0;
     }
 
     /**

--- a/src/SeablastView.php
+++ b/src/SeablastView.php
@@ -56,7 +56,7 @@ class SeablastView
             if (isset($this->params->httpCode)) {
                 Assert::inArray(
                     $this->params->httpCode,
-                    [301, 302, 303],
+                    [301, 302, 303, 307, 308],
                     'Unauthorized redirect HTTP code %s'
                 );
             } else {
@@ -131,7 +131,7 @@ class SeablastView
             throw new \Exception('not status but httpCode is wanted'); // debug deprecated
         }
         if (isset($this->params->httpCode) && is_scalar($this->params->httpCode)) {
-            // todo in_array((int),[allowed codes] to replace basic validation below
+            // accepts HTTP codes 100-599 even though some of them might not be defined
             if ((int) $this->params->httpCode < 100 || (int) $this->params->httpCode > 599) {
                 throw new UnknownHttpCodeException('Unknown HTTP code: ' . (int) $this->params->httpCode);
             }


### PR DESCRIPTION
### Added
- redirection HTTP code allows for 307 and 308

### Changed
- use [seablast/logger](https://github.com/WorkOfStan/seablast-logger), a [PSR-3](https://www.php-fig.org/psr/psr-3/) compliant logger with verbosity control, as a logger for Tracy.
- following SQL statements are not logged: DESCRIB, DO, EXPLAIN as they do not change the table data

### Fixed
- `.htaccess` checked