### PR TITLE
If Seablast/Auth extension is present, use its configuration. Log location change enabled.

### DIFF
--- a/.github/workflows/php-composer-dependencies.yml
+++ b/.github/workflows/php-composer-dependencies.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.
   call-workflow:
-    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@feature/composer-phpstan
+    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@main
     with:
       # JSON
       php-version: '["7.2", "7.3", "7.4", "8.1", "8.2", "8.3"]'

--- a/.github/workflows/php-composer-dependencies.yml
+++ b/.github/workflows/php-composer-dependencies.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.
   call-workflow:
-    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@main
+    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@dev-feature/composer-phpstan
     with:
       # JSON
       php-version: '["7.2", "7.3", "7.4", "8.1", "8.2", "8.3"]'

--- a/.github/workflows/php-composer-dependencies.yml
+++ b/.github/workflows/php-composer-dependencies.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.
   call-workflow:
-    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@dev-feature/composer-phpstan
+    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@feature/composer-phpstan
     with:
       # JSON
       php-version: '["7.2", "7.3", "7.4", "8.1", "8.2", "8.3"]'

--- a/.github/workflows/prettier-fix.yml
+++ b/.github/workflows/prettier-fix.yml
@@ -15,14 +15,12 @@ permissions:
 
 jobs:
   prettier-fix:
-    # Run only if the actor is not the GitHub Actions bot
-    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     # Limit the running time
     timeout-minutes: 10
     steps:
       - name: Invoke the Prettier fix
         # Use the latest commit in the main branch.
-        uses: WorkOfStan/prettier-fix@v1.0.3
-        #with:
-        #  node-version: "20"
+        uses: WorkOfStan/prettier-fix@v1.1.0
+        with:
+          commit-changes: true

--- a/.github/workflows/prettier-fix.yml
+++ b/.github/workflows/prettier-fix.yml
@@ -1,6 +1,14 @@
 ---
 name: Prettier-fix
-on: [pull_request, push]
+on:
+  push:
+    branches-ignore:
+      # notest branches to ignore testing of partial online commits
+      - "notest/**"
+  pull_request:
+    branches-ignore:
+      # notest branches to ignore testing of partial online commits
+      - "notest/**"
 
 permissions:
   contents: write
@@ -15,6 +23,6 @@ jobs:
     steps:
       - name: Invoke the Prettier fix
         # Use the latest commit in the main branch.
-        uses: WorkOfStan/prettier-fix@main
+        uses: WorkOfStan/prettier-fix@v1.0.3
         #with:
         #  node-version: "20"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed` for changes in existing functionality
 
+- SeablastConfiguration::exists simplified
+
 ### `Deprecated` for soon-to-be removed features
 
 ### `Removed` for now removed features
 
 - PHPUnit generates some weird errors with PHP/8.0. So the PHP/8.0 support removed.
+- some Assertions removed as not needed for PHPStan/2
 
 ### `Fixed` for any bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Changed` for changes in existing functionality
 
 - SeablastConfiguration::exists simplified
+- updated dependencies not to refer below PHP/7.2
 
 ### `Deprecated` for soon-to-be removed features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,29 +10,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added` for new features
 
 - TableViewModel for admin.latte
-- PHPUnit tests. The PHPUnit tests use the database configuration from `./conf/phinx.local.php`, so the library require-dev Phinx, ensuring PHPUnit tests work on GitHub as well.
-- SeablastMysqli::queryStrict now changes mysqli_sql_exception to the expected DbmsException. (Useful for PHP/8.x tests on GitHub.)
-- [prettier-fix](https://github.com/WorkOfStan/prettier-fix) included to fix all those `VALIDATE_something_PRETTIER` that are now crucial part of super-linter
-- if [Seablast/Auth](https://github.com/WorkOfStan/seablast-auth) extension is present, use its configuration
-- `{block script}{/block}` to BlueprintWeb.latte
-- change of the log location enabled
 
 ### `Changed` for changes in existing functionality
-
-- SeablastConfiguration::exists simplified
-- updated dependencies not to refer below PHP/7.2
-- SeablastMysqli::query error shows up to 1500 characters of a query that ended up with a database error (instead of truncating to the default 150 characters)
 
 ### `Deprecated` for soon-to-be removed features
 
 ### `Removed` for now removed features
 
-- PHPUnit generates some weird errors with PHP/8.0. So the PHP/8.0 support removed.
-- some Assertions removed as not needed for PHPStan/2
-
 ### `Fixed` for any bugfixes
 
 ### `Security` in case of vulnerabilities
+
+## [0.2.5] - 2024-12-20
+
+### Added
+
+- PHPUnit tests. The PHPUnit tests use the database configuration from `./conf/phinx.local.php`, so the library require-dev Phinx, ensuring PHPUnit tests work on GitHub as well.
+- SeablastMysqli::queryStrict now changes mysqli_sql_exception to the expected DbmsException. (Useful for PHP/8.x tests on GitHub.)
+- [prettier-fix](https://github.com/WorkOfStan/prettier-fix) included to fix all those `VALIDATE_something_PRETTIER` that are now crucial part of super-linter
+- if [Seablast/Auth](https://github.com/WorkOfStan/seablast-auth) extension is present, use its configuration
+- `{block script}{/block}` to BlueprintWeb.latte
+- change of the log location enabled (single settings for Seablast\Logger, Tracy\Debugger and SeablastMysqli)
+
+### Changed
+
+- SeablastConfiguration::exists simplified
+- updated dependencies not to refer below PHP/7.2
+- SeablastMysqli::query error shows up to 1500 characters of a query that ended up with a database error (instead of truncating to the default 150 characters)
+
+### Removed
+
+- PHPUnit generates some weird errors with PHP/8.0. So the PHP/8.0 support removed.
+- some Assertions removed as not needed for PHPStan/2
 
 ## [0.2.4] - 2024-08-04
 
@@ -205,7 +214,8 @@ PHPUnit tests ready
 - model returns knowledge()
 - a nice Under construction page
 
-[Unreleased]: https://github.com/WorkOfStan/seablast/compare/v0.2.4...HEAD?w=1
+[Unreleased]: https://github.com/WorkOfStan/seablast/compare/v0.2.5...HEAD?w=1
+[0.2.5]: https://github.com/WorkOfStan/seablast/compare/v0.2.4...v0.2.5?w=1
 [0.2.4]: https://github.com/WorkOfStan/seablast/compare/v0.2.3.5...v0.2.4?w=1
 [0.2.3.5]: https://github.com/WorkOfStan/seablast/compare/v0.2.3.4...v0.2.3.5?w=1
 [0.2.3.4]: https://github.com/WorkOfStan/seablast/compare/v0.2.3.3...v0.2.3.4?w=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,7 +138,7 @@ PHPUnit tests ready
 ### Added
 
 - show HTTP code error Tracy BarPanel
-- /api/error for is always available (if not overriden): Log errors reported by Ajax saved to the standard error log
+- /api/error is always available (if not overriden): Log errors reported by Ajax saved to the standard error log
 
 ### Changed **BREAKING**
 
@@ -196,16 +196,16 @@ PHPUnit tests ready
 - model returns knowledge()
 - a nice Under construction page
 
-[Unreleased]: https://github.com/WorkOfStan/seablast/compare/v0.2.4...HEAD
-[0.2.4]: https://github.com/WorkOfStan/seablast/compare/v0.2.3.5...v0.2.4
-[0.2.3.5]: https://github.com/WorkOfStan/seablast/compare/v0.2.3.4...v0.2.3.5
-[0.2.3.4]: https://github.com/WorkOfStan/seablast/compare/v0.2.3.3...v0.2.3.4
-[0.2.3.3]: https://github.com/WorkOfStan/seablast/compare/v0.2.3.2...v0.2.3.3
-[0.2.3.2]: https://github.com/WorkOfStan/seablast/compare/v0.2.3.1...v0.2.3.2
-[0.2.3.1]: https://github.com/WorkOfStan/seablast/compare/v0.2.3...v0.2.3.1
-[0.2.3]: https://github.com/WorkOfStan/seablast/compare/v0.2.2...v0.2.3
-[0.2.2]: https://github.com/WorkOfStan/seablast/compare/v0.2.1...v0.2.2
-[0.2.1]: https://github.com/WorkOfStan/seablast/compare/v0.2...v0.2.1
-[0.2]: https://github.com/WorkOfStan/seablast/compare/v0.1.1...v0.2
-[0.1.1]: https://github.com/WorkOfStan/seablast/compare/v0.1...v0.1.1
+[Unreleased]: https://github.com/WorkOfStan/seablast/compare/v0.2.4...HEAD?w=1
+[0.2.4]: https://github.com/WorkOfStan/seablast/compare/v0.2.3.5...v0.2.4?w=1
+[0.2.3.5]: https://github.com/WorkOfStan/seablast/compare/v0.2.3.4...v0.2.3.5?w=1
+[0.2.3.4]: https://github.com/WorkOfStan/seablast/compare/v0.2.3.3...v0.2.3.4?w=1
+[0.2.3.3]: https://github.com/WorkOfStan/seablast/compare/v0.2.3.2...v0.2.3.3?w=1
+[0.2.3.2]: https://github.com/WorkOfStan/seablast/compare/v0.2.3.1...v0.2.3.2?w=1
+[0.2.3.1]: https://github.com/WorkOfStan/seablast/compare/v0.2.3...v0.2.3.1?w=1
+[0.2.3]: https://github.com/WorkOfStan/seablast/compare/v0.2.2...v0.2.3?w=1
+[0.2.2]: https://github.com/WorkOfStan/seablast/compare/v0.2.1...v0.2.2?w=1
+[0.2.1]: https://github.com/WorkOfStan/seablast/compare/v0.2...v0.2.1?w=1
+[0.2]: https://github.com/WorkOfStan/seablast/compare/v0.1.1...v0.2?w=1
+[0.1.1]: https://github.com/WorkOfStan/seablast/compare/v0.1...v0.1.1?w=1
 [0.1]: https://github.com/WorkOfStan/seablast/releases/tag/v0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SeablastMysqli::queryStrict now changes mysqli_sql_exception to the expected DbmsException. (Useful for PHP/8.x tests on GitHub.)
 - [prettier-fix](https://github.com/WorkOfStan/prettier-fix) included to fix all those `VALIDATE_something_PRETTIER` that are now crucial part of super-linter
 - if [Seablast/Auth](https://github.com/WorkOfStan/seablast-auth) extension is present, use its configuration
+- `{block script}{/block}` to BlueprintWeb.latte
 
 ### `Changed` for changes in existing functionality
 
 - SeablastConfiguration::exists simplified
 - updated dependencies not to refer below PHP/7.2
+- SeablastMysqli::query error shows up to 1500 characters of a query that ended up with a database error (instead of truncating to the default 150 characters)
 
 ### `Deprecated` for soon-to-be removed features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPUnit tests. The PHPUnit tests use the database configuration from `./conf/phinx.local.php`, so the library require-dev Phinx, ensuring PHPUnit tests work on GitHub as well.
 - SeablastMysqli::queryStrict now changes mysqli_sql_exception to the expected DbmsException. (Useful for PHP/8.x tests on GitHub.)
 - [prettier-fix](https://github.com/WorkOfStan/prettier-fix) included to fix all those `VALIDATE_something_PRETTIER` that are now crucial part of super-linter
+- if [Seablast/Auth](https://github.com/WorkOfStan/seablast-auth) extension is present, use its configuration
 
 ### `Changed` for changes in existing functionality
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TableViewModel for admin.latte
 - PHPUnit tests. The PHPUnit tests use the database configuration from `./conf/phinx.local.php`, so the library require-dev Phinx, ensuring PHPUnit tests work on GitHub as well.
 - SeablastMysqli::queryStrict now changes mysqli_sql_exception to the expected DbmsException. (Useful for PHP/8.x tests on GitHub.)
+- [prettier-fix](https://github.com/WorkOfStan/prettier-fix) included to fix all those `VALIDATE_something_PRETTIER` that are now crucial part of super-linter
 
 ### `Changed` for changes in existing functionality
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [prettier-fix](https://github.com/WorkOfStan/prettier-fix) included to fix all those `VALIDATE_something_PRETTIER` that are now crucial part of super-linter
 - if [Seablast/Auth](https://github.com/WorkOfStan/seablast-auth) extension is present, use its configuration
 - `{block script}{/block}` to BlueprintWeb.latte
+- change of the log location enabled
 
 ### `Changed` for changes in existing functionality
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The framework takes care of logs, database, multiple languages, user friendly HT
 ## Configuration
 
 - the default environment parameters are set in the [conf/default.conf.php](conf/default.conf.php)
+- if Seablast/Auth extension is present, use its configuration
 - everything can be overriden in the web app's `conf/app.conf.php` or even in its local deployment `conf/app.conf.local.php`
 - set the default phinx environment in the phinx configuration: `['environments']['default_environment']`
 

--- a/TODO.md
+++ b/TODO.md
@@ -18,4 +18,3 @@ All planned changes to this project are documented in this file.
 ## Governance
 
 - 231206, cut Latte out of the core Seablast to be used as Seablast/render-latte
-- 231206, either add PHPUnit tests or remove Test from composer.json

--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,6 @@ All planned changes to this project are documented in this file.
 
 - 240111, Messages from server and Ajax to user friendly closable banners; how to localize these messages - by some l10n?
 - 240119, APP_MAPPING restrictToGroups 1-admin, 2-contentAdmin, 3-user, other can be added in the app (use constants instead of magic numbers)
-- 240119, check an open source social authentication library <https://github.com/hybridauth/hybridauth>
 
 ## UX
 

--- a/Test/SeablastModelTest.php
+++ b/Test/SeablastModelTest.php
@@ -58,7 +58,7 @@ class SeablastModelTest extends TestCase
         $params = $model->getParameters();
         // TODO change to PHP version test instead of ignoring function.alreadyNarrowedType
         /** @phpstan-ignore function.alreadyNarrowedType */
-        if (method_exists($this, 'assertObjectHasProperty')) {            
+        if (method_exists($this, 'assertObjectHasProperty')) {
             $this->assertObjectHasProperty('data', $params);
             /** @phpstan-ignore function.alreadyNarrowedType */
         } elseif (method_exists($this, 'assertObjectHasAttribute')) {

--- a/Test/SeablastModelTest.php
+++ b/Test/SeablastModelTest.php
@@ -56,12 +56,15 @@ class SeablastModelTest extends TestCase
 
         $model = new SeablastModel($this->controller, new Superglobals());
         $params = $model->getParameters();
-        if (method_exists($this, 'assertObjectHasProperty')) {
+        // TODO change to PHP version test instead of ignoring function.alreadyNarrowedType
+        /** @phpstan-ignore function.alreadyNarrowedType */
+        if (method_exists($this, 'assertObjectHasProperty')) {            
             $this->assertObjectHasProperty('data', $params);
+            /** @phpstan-ignore function.alreadyNarrowedType */
         } elseif (method_exists($this, 'assertObjectHasAttribute')) {
             $this->assertObjectHasAttribute('data', $params); //deprecated in favor is assertObjectHasProperty
         } else {
-            $this->assertTrue(false, 'Cannot make sure that data has params attribute/property');
+            $this->fail('Cannot make sure that data has params attribute/property');
         }
         $this->assertEquals('value', $params->data);
     }

--- a/Test/SeablastMysqliTest.php
+++ b/Test/SeablastMysqliTest.php
@@ -69,10 +69,7 @@ class SeablastMysqliTest extends TestCase
             // that's how it should be
         } catch (\Exception $e) {
             // Handle any other exceptions (fallback)
-            $this->assertTrue(
-                false,
-                'Failure was caught but as a generic exception, not DbmsException: ' . $e->getMessage()
-            );
+            $this->fail('Failure was caught but as a generic exception, not DbmsException: ' . $e->getMessage());
         }
         // Check if the query was logged with the error
     }

--- a/composer.json
+++ b/composer.json
@@ -4,17 +4,17 @@
   "type": "library",
   "require": {
     "php": "^7.2 || ^8.1",
-    "latte/latte": ">=2.4.6 <2.11.3",
-    "nette/utils": "^2.4.8 || ^3.2.2",
+    "latte/latte": "^2.11.7 || ^3",
+    "nette/utils": "^3.2.10 || ^4.0.5",
     "seablast/interfaces": "^0.1",
     "seablast/logger": "^2.0",
     "symfony/security-csrf": "^4.4.37 || ^5 || ^6 || ^7",
-    "tracy/tracy": "^2.4.10",
-    "webmozart/assert": "^1.9.1"
+    "tracy/tracy": "^2.9.8",
+    "webmozart/assert": "^1.11.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.4 || ^9 || ^10 || ^11",
-    "robmorgan/phinx": "^0.10.6 || ^0.12.3"
+    "robmorgan/phinx": "^0.12.13 || ^0.13.4 || ^0.14.0 || ^0.15.5 || ^0.16.5"
   },
   "suggest": {
     "seablast/auth": "No-password authentication and authorisation extension for Seablast for PHP"

--- a/conf/default.conf.php
+++ b/conf/default.conf.php
@@ -31,6 +31,7 @@ return static function (SeablastConfiguration $SBConfig): void {
         ->setString(SeablastConstant::SB_INI_SET_DISPLAY_ERRORS, '0') // errors only in the log; override locally
         ->setArrayString(SeablastConstant::DEBUG_IP_LIST, []) // default list with IPs to show Tracy
         ->setInt(SeablastConstant::SB_LOGGING_LEVEL, 3) // log warnings and more severe events
+        ->setString(SeablastConstant::SB_LOG_DIRECTORY, APP_DIR . '/log') // change of the log location is possible
         // Database
         // Does not have to be 'testing' expected by the automatic GitHub tests as environment is set in the unit tests
         // like this: `$setup->getConfiguration()->setString(SeablastConstant::SB_PHINX_ENVIRONMENT, 'testing');`

--- a/conf/phpstan.app.neon
+++ b/conf/phpstan.app.neon
@@ -9,3 +9,5 @@ parameters:
       - ../defineAppDir.php
     scanDirectories:
       - ../src
+    #tips:
+    #    treatPhpDocTypesAsCertain: false

--- a/conf/phpstan.app.neon
+++ b/conf/phpstan.app.neon
@@ -9,5 +9,7 @@ parameters:
       - ../defineAppDir.php
     scanDirectories:
       - ../src
+    # as PHPStan 2.0 reports other things than 1.x
+    reportUnmatchedIgnoredErrors: false
     #tips:
     #    treatPhpDocTypesAsCertain: false

--- a/conf/phpstan.app.neon
+++ b/conf/phpstan.app.neon
@@ -9,7 +9,5 @@ parameters:
       - ../defineAppDir.php
     scanDirectories:
       - ../src
-    # as PHPStan 2.0 reports other things than 1.x
+    # as PHPStan 2.0 reports other things than 1.x (and 1.x is still needed to support PHP/7.2 and 7.3
     reportUnmatchedIgnoredErrors: false
-    #tips:
-    #    treatPhpDocTypesAsCertain: false

--- a/defineAppDir.php
+++ b/defineAppDir.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 // Keep this in a separate file in order to avoid declaring new symbols in index.php
 define(
     'APP_DIR',

--- a/index.php
+++ b/index.php
@@ -19,11 +19,14 @@ require_once APP_DIR . '/vendor/autoload.php';
 Debugger::setSessionStorage(new Tracy\NativeSession());
 $setup = new SeablastSetup(); // combine configuration files into a valid configuration
 // $setup contains the info for Debugger setup
-$developmentEnvironment = (
-    in_array($_SERVER['REMOTE_ADDR'], ['::1', '127.0.0.1']) ||
-    in_array($_SERVER['REMOTE_ADDR'], $setup->getConfiguration()->getArrayString(SeablastConstant::DEBUG_IP_LIST))
+Debugger::enable(
+    (
+        // development environment
+        in_array($_SERVER['REMOTE_ADDR'], ['::1', '127.0.0.1']) ||
+        in_array($_SERVER['REMOTE_ADDR'], $setup->getConfiguration()->getArrayString(SeablastConstant::DEBUG_IP_LIST))
+    ) ? Debugger::DEVELOPMENT : Debugger::PRODUCTION,
+    APP_DIR . '/log'
 );
-Debugger::enable($developmentEnvironment ? Debugger::DEVELOPMENT : Debugger::PRODUCTION, APP_DIR . '/log');
 
 // Wrap _GET, _POST, _SESSION and _SERVER for sanitizing and testing
 $superglobals = new Superglobals($_GET, $_POST, $_SERVER); // $_SESSION hasn't started, yet

--- a/index.php
+++ b/index.php
@@ -25,7 +25,7 @@ Debugger::enable(
         in_array($_SERVER['REMOTE_ADDR'], ['::1', '127.0.0.1']) ||
         in_array($_SERVER['REMOTE_ADDR'], $setup->getConfiguration()->getArrayString(SeablastConstant::DEBUG_IP_LIST))
     ) ? Debugger::DEVELOPMENT : Debugger::PRODUCTION,
-    APP_DIR . '/log'
+    $setup->getConfiguration()->getString(SeablastConstant::SB_LOG_DIRECTORY)
 );
 
 // Wrap _GET, _POST, _SESSION and _SERVER for sanitizing and testing

--- a/src/Apis/GenericRestApiJsonModel.php
+++ b/src/Apis/GenericRestApiJsonModel.php
@@ -30,17 +30,16 @@ class GenericRestApiJsonModel implements SeablastModelInterface
     protected $configuration;
     /** @var object input JSON transformed to the data */
     protected $data;
-    /** @var string API response message */
-    protected $message = 'Input ready for processing.';
     /** @var int HTTP status to be used as a default response */
     protected $httpCode = 200;
+    /** @var string API response message */
+    protected $message = 'Input ready for processing.';
     /** @var Superglobals */
     protected $superglobals;
 
     /**
      * @param SeablastConfiguration $configuration
      * @param Superglobals $superglobals
-     * @throws \Exception
      */
     public function __construct(SeablastConfiguration $configuration, Superglobals $superglobals)
     {
@@ -112,8 +111,7 @@ class GenericRestApiJsonModel implements SeablastModelInterface
             $this->httpCode = 400; // Bad Request
             $this->message = 'Invalid JSON input'; // TODO be more specific by https://www.php.net/json_last_error
             return;
-        }
-        if (!is_object($jsonDecoded)) { // maybe this is redundant vs json_last_error above
+        } elseif (!is_object($jsonDecoded)) { // maybe this is redundant vs json_last_error above
             Debugger::barDump("Decoded JSON doesn't translate to an object", 'ERROR on input');
             Debugger::log("Decoded JSON doesn't translate to an object", ILogger::ERROR);
             $this->httpCode = 400; // Bad Request

--- a/src/Models/MockJsonModel.php
+++ b/src/Models/MockJsonModel.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Seablast\Seablast\Models;
 
 use Seablast\Seablast\SeablastConfiguration;
-use Seablast\Seablast\SeablastConstant;
 use Seablast\Seablast\SeablastModelInterface;
 use Seablast\Seablast\Superglobals;
 use stdClass;

--- a/src/Models/MockModel.php
+++ b/src/Models/MockModel.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Seablast\Seablast\Models;
 
 use Seablast\Seablast\SeablastConfiguration;
-use Seablast\Seablast\SeablastConstant;
 use Seablast\Seablast\SeablastModelInterface;
 use Seablast\Seablast\Superglobals;
 use stdClass;

--- a/src/SeablastConfiguration.php
+++ b/src/SeablastConfiguration.php
@@ -75,8 +75,12 @@ class SeablastConfiguration
             "Phinx environment `{$environment}` isn't defined - check SB_PHINX_ENVIRONMENT or default_environment"
         );
         Assert::isArray($phinx['environments'][$environment]);
-        $port = isset($phinx['environments'][$environment]['port'])
-            ? (int) $phinx['environments'][$environment]['port'] : null;
+        if (isset($phinx['environments'][$environment]['port'])) {
+            Assert::scalar($phinx['environments'][$environment]['port']);
+            $port = (int) $phinx['environments'][$environment]['port'];
+        } else {
+            $port = null;
+        }
         $this->connection = new SeablastMysqli(
             $phinx['environments'][$environment]['host'], // todo fix localhost
             $phinx['environments'][$environment]['user'],
@@ -244,6 +248,7 @@ class SeablastConfiguration
         //Assert::string($property);
         //Assert::string($key);
         foreach ($value as $row) {
+            /** @phpstan-ignore staticMethod.alreadyNarrowedType */
             Assert::string($row);
         }
         $this->optionsArrayArrayString[$property][$key] = $value;
@@ -259,6 +264,7 @@ class SeablastConfiguration
     {
         //Assert::string($property);
         foreach ($value as $row) {
+            /** @phpstan-ignore staticMethod.alreadyNarrowedType */
             Assert::integer($row);
         }
         $this->optionsArrayInt[$property] = $value;
@@ -274,6 +280,7 @@ class SeablastConfiguration
     {
         //Assert::string($property);
         foreach ($value as $row) {
+            /** @phpstan-ignore staticMethod.alreadyNarrowedType */
             Assert::string($row);
         }
         $this->optionsArrayString[$property] = $value;

--- a/src/SeablastConfiguration.php
+++ b/src/SeablastConfiguration.php
@@ -146,7 +146,6 @@ class SeablastConfiguration
      */
     public function exists(string $property): bool
     {
-        //Assert::string($property);
         $methods = [
             'getArrayArrayString',
             'getArrayInt',
@@ -174,7 +173,6 @@ class SeablastConfiguration
      */
     public function getArrayArrayString(string $property): array
     {
-        //Assert::string($property);
         if (!array_key_exists($property, $this->optionsArrayArrayString)) {
             throw new SeablastConfigurationException('No array of string array for the property ' . $property);
         }
@@ -188,7 +186,6 @@ class SeablastConfiguration
      */
     public function getArrayInt(string $property): array
     {
-        //Assert::string($property);
         if (!array_key_exists($property, $this->optionsArrayInt)) {
             throw new SeablastConfigurationException('No array int for the property ' . $property);
         }
@@ -202,7 +199,6 @@ class SeablastConfiguration
      */
     public function getArrayString(string $property): array
     {
-        //Assert::string($property);
         if (!array_key_exists($property, $this->optionsArrayString)) {
             throw new SeablastConfigurationException('No array string for the property ' . $property);
         }
@@ -216,7 +212,6 @@ class SeablastConfiguration
      */
     public function getInt(string $property): int
     {
-        //Assert::string($property);
         if (!array_key_exists($property, $this->optionsInt)) {
             throw new SeablastConfigurationException('No int value for the property ' . $property);
         }
@@ -230,7 +225,6 @@ class SeablastConfiguration
      */
     public function getString(string $property): string
     {
-        //Assert::string($property);
         if (!array_key_exists($property, $this->optionsString)) {
             throw new SeablastConfigurationException('No string value for the property ' . $property);
         }
@@ -245,8 +239,6 @@ class SeablastConfiguration
      */
     public function setArrayArrayString(string $property, string $key, array $value): self
     {
-        //Assert::string($property);
-        //Assert::string($key);
         foreach ($value as $row) {
             /** @phpstan-ignore staticMethod.alreadyNarrowedType */
             Assert::string($row);
@@ -262,7 +254,6 @@ class SeablastConfiguration
      */
     public function setArrayInt(string $property, array $value): self
     {
-        //Assert::string($property);
         foreach ($value as $row) {
             /** @phpstan-ignore staticMethod.alreadyNarrowedType */
             Assert::integer($row);
@@ -278,7 +269,6 @@ class SeablastConfiguration
      */
     public function setArrayString(string $property, array $value): self
     {
-        //Assert::string($property);
         foreach ($value as $row) {
             /** @phpstan-ignore staticMethod.alreadyNarrowedType */
             Assert::string($row);
@@ -294,8 +284,6 @@ class SeablastConfiguration
      */
     public function setInt(string $property, int $value): self
     {
-        //Assert::string($property);
-        //Assert::integer($value);
         $this->optionsInt[$property] = $value;
         return $this;
     }
@@ -307,8 +295,6 @@ class SeablastConfiguration
      */
     public function setString(string $property, string $value): self
     {
-        //Assert::string($property);
-        //Assert::string($value);
         $this->optionsString[$property] = $value;
         return $this;
     }

--- a/src/SeablastConfiguration.php
+++ b/src/SeablastConfiguration.php
@@ -36,11 +36,11 @@ class SeablastConfiguration
 
     public function __construct()
     {
-        $this->flag = new SeablastFlag(); // todo je flag zde k něčemu?
+        $this->flag = new SeablastFlag(); // initialization instead of `private $optionsX = [];` above
     }
 
     /**
-     * Access to database with lazy initialisation.
+     * Access to database with lazy initialization.
      *
      * @return SeablastMysqli
      */
@@ -68,11 +68,13 @@ class SeablastConfiguration
         $environment = $this->exists(SeablastConstant::SB_PHINX_ENVIRONMENT)
             ? $this->getString(SeablastConstant::SB_PHINX_ENVIRONMENT)
             : ($phinx['environments']['default_environment'] ?? 'undefined');
+        Assert::string($environment);
         Assert::keyExists(
             $phinx['environments'],
             $environment,
             "Phinx environment `{$environment}` isn't defined - check SB_PHINX_ENVIRONMENT or default_environment"
         );
+        Assert::isArray($phinx['environments'][$environment]);
         $port = isset($phinx['environments'][$environment]['port'])
             ? (int) $phinx['environments'][$environment]['port'] : null;
         $this->connection = new SeablastMysqli(
@@ -110,7 +112,7 @@ class SeablastConfiguration
      * Read the database connection parameters from an external phinx configuration.
      *
      * @return array<mixed>
-     * @throws \Exception
+     * @throws DbmsException
      */
     private static function dbmsReadPhinx(): array
     {
@@ -121,14 +123,15 @@ class SeablastConfiguration
     }
 
     /**
-     * Returns true on connected, false on not connected:
+     * Returns true if connected, false otherwise.
+     *
      * So that the SQL Bar Panel is not requested in vain.
      *
      * @return bool
      */
     public function dbmsStatus(): bool
     {
-        return is_object($this->connection) && is_a($this->connection, '\mysqli');
+        return $this->connection instanceof \mysqli;
     }
 
     /**
@@ -139,7 +142,7 @@ class SeablastConfiguration
      */
     public function exists(string $property): bool
     {
-        Assert::string($property);
+        //Assert::string($property);
         $methods = [
             'getArrayArrayString',
             'getArrayInt',
@@ -148,26 +151,26 @@ class SeablastConfiguration
             'getString'
         ];
 
-        $exceptionCount = 0;
-
         foreach ($methods as $method) {
             try {
-                $result = $this->$method($property);
+                $this->$method($property);
+                return true;
             } catch (SeablastConfigurationException $ex) {
-                $exceptionCount++;
+                // Ignore and continue
             }
         }
 
-        return $exceptionCount < count($methods);
+        return false;
     }
 
     /**
      * @param string $property
      * @return array<array<string>>
+     * @throws SeablastConfigurationException
      */
     public function getArrayArrayString(string $property): array
     {
-        Assert::string($property);
+        //Assert::string($property);
         if (!array_key_exists($property, $this->optionsArrayArrayString)) {
             throw new SeablastConfigurationException('No array of string array for the property ' . $property);
         }
@@ -177,10 +180,11 @@ class SeablastConfiguration
     /**
      * @param string $property
      * @return array<int>
+     * @throws SeablastConfigurationException
      */
     public function getArrayInt(string $property): array
     {
-        Assert::string($property);
+        //Assert::string($property);
         if (!array_key_exists($property, $this->optionsArrayInt)) {
             throw new SeablastConfigurationException('No array int for the property ' . $property);
         }
@@ -190,10 +194,11 @@ class SeablastConfiguration
     /**
      * @param string $property
      * @return array<string>
+     * @throws SeablastConfigurationException
      */
     public function getArrayString(string $property): array
     {
-        Assert::string($property);
+        //Assert::string($property);
         if (!array_key_exists($property, $this->optionsArrayString)) {
             throw new SeablastConfigurationException('No array string for the property ' . $property);
         }
@@ -203,10 +208,11 @@ class SeablastConfiguration
     /**
      * @param string $property
      * @return int
+     * @throws SeablastConfigurationException
      */
     public function getInt(string $property): int
     {
-        Assert::string($property);
+        //Assert::string($property);
         if (!array_key_exists($property, $this->optionsInt)) {
             throw new SeablastConfigurationException('No int value for the property ' . $property);
         }
@@ -216,10 +222,11 @@ class SeablastConfiguration
     /**
      * @param string $property
      * @return string
+     * @throws SeablastConfigurationException
      */
     public function getString(string $property): string
     {
-        Assert::string($property);
+        //Assert::string($property);
         if (!array_key_exists($property, $this->optionsString)) {
             throw new SeablastConfigurationException('No string value for the property ' . $property);
         }
@@ -234,8 +241,8 @@ class SeablastConfiguration
      */
     public function setArrayArrayString(string $property, string $key, array $value): self
     {
-        Assert::string($property);
-        Assert::string($key);
+        //Assert::string($property);
+        //Assert::string($key);
         foreach ($value as $row) {
             Assert::string($row);
         }
@@ -250,7 +257,7 @@ class SeablastConfiguration
      */
     public function setArrayInt(string $property, array $value): self
     {
-        Assert::string($property);
+        //Assert::string($property);
         foreach ($value as $row) {
             Assert::integer($row);
         }
@@ -265,7 +272,7 @@ class SeablastConfiguration
      */
     public function setArrayString(string $property, array $value): self
     {
-        Assert::string($property);
+        //Assert::string($property);
         foreach ($value as $row) {
             Assert::string($row);
         }
@@ -280,8 +287,8 @@ class SeablastConfiguration
      */
     public function setInt(string $property, int $value): self
     {
-        Assert::string($property);
-        Assert::integer($value);
+        //Assert::string($property);
+        //Assert::integer($value);
         $this->optionsInt[$property] = $value;
         return $this;
     }
@@ -293,8 +300,8 @@ class SeablastConfiguration
      */
     public function setString(string $property, string $value): self
     {
-        Assert::string($property);
-        Assert::string($value);
+        //Assert::string($property);
+        //Assert::string($value);
         $this->optionsString[$property] = $value;
         return $this;
     }

--- a/src/SeablastConstant.php
+++ b/src/SeablastConstant.php
@@ -72,6 +72,10 @@ class SeablastConstant
      */
     public const SB_LOGGING_LEVEL = 'SB:SB_LOGGING_LEVEL';
     /**
+     * @var string log location
+     */
+    public const SB_LOG_DIRECTORY = 'SB_LOG_DIRECTORY';
+    /**
      * @var string flag whether to send emails to admin
      */
     public const ADMIN_MAIL_ENABLED = 'SB:ADMIN_MAIL:ENABLED';

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -142,7 +142,8 @@ class SeablastController
                         $this->logger = new Logger([
                                 'logging_level' => $this->configuration->getInt($property),
                                 'error_log_message_type' => 3,
-                                'logging_file' => APP_DIR . '/log/seablast',
+                                'logging_file' => $this->configuration->getString(SeablastConstant::SB_LOG_DIRECTORY)
+                                    . '/seablast',
                                 'mail_for_admin_enabled' => ((
                                     $this->configuration->flag->status(SeablastConstant::ADMIN_MAIL_ENABLED)
                                     && $this->configuration->exists(SeablastConstant::ADMIN_MAIL_ADDRESS)

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -181,7 +181,7 @@ class SeablastController
         $isHttps = (!empty($this->superglobals->server['REQUEST_SCHEME'])
             && $this->superglobals->server['REQUEST_SCHEME'] == 'https') ||
             (!empty($this->superglobals->server['HTTPS']) && $this->superglobals->server['HTTPS'] == 'on') ||
-            (!empty($this->superglobals->server['SERVER_PORT']) && $this->superglobals->server['SERVER_PORT'] == '443');    
+            (!empty($this->superglobals->server['SERVER_PORT']) && $this->superglobals->server['SERVER_PORT'] == '443');
         $this->configuration->setString(
             // Note: without trailing slash even for app root in domain root, i.e. https://www.service.com
             SeablastConstant::SB_APP_ROOT_ABSOLUTE_URL,

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -43,7 +43,7 @@ class SeablastController
      */
     public function __construct(SeablastConfiguration $configuration, Superglobals $superglobals)
     {
-        // Wrapped _GET, _POST, _SESSION and _SERVER for sanitizing and testing
+        // Wrapped _GET, _POST, _SERVER and _SESSION for sanitizing and testing
         $this->superglobals = $superglobals;
         $this->configuration = $configuration;
         Debugger::barDump($this->configuration, 'Configuration at SeablastController start');

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -52,8 +52,10 @@ class SeablastController
             // Controller can be fired up multiple times in PHPUnit, but this part may run only once
             $this->applyConfigurationBeforeSession();
         } else {
+            $serverPhpSelf = $_SERVER['PHP_SELF'];
+            Assert::string($serverPhpSelf);
             Debugger::log(
-                'Session already started: not invoking applyConfigurationBeforeSession by ' . $_SERVER['PHP_SELF'],
+                'Session already started: not invoking applyConfigurationBeforeSession by ' . $serverPhpSelf,
                 ILogger::INFO
             );
         }
@@ -171,6 +173,7 @@ class SeablastController
      */
     private function applyConfigurationWithSession(): void
     {
+        Assert::string($this->superglobals->server['HTTP_HOST']);
         $scriptName = filter_var($this->superglobals->server['SCRIPT_NAME'], FILTER_SANITIZE_URL);
         Assert::string($scriptName);
         $this->scriptName = $scriptName;
@@ -178,7 +181,7 @@ class SeablastController
         $isHttps = (!empty($this->superglobals->server['REQUEST_SCHEME'])
             && $this->superglobals->server['REQUEST_SCHEME'] == 'https') ||
             (!empty($this->superglobals->server['HTTPS']) && $this->superglobals->server['HTTPS'] == 'on') ||
-            (!empty($this->superglobals->server['SERVER_PORT']) && $this->superglobals->server['SERVER_PORT'] == '443');
+            (!empty($this->superglobals->server['SERVER_PORT']) && $this->superglobals->server['SERVER_PORT'] == '443');    
         $this->configuration->setString(
             // Note: without trailing slash even for app root in domain root, i.e. https://www.service.com
             SeablastConstant::SB_APP_ROOT_ABSOLUTE_URL,

--- a/src/SeablastFlag.php
+++ b/src/SeablastFlag.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Seablast\Seablast;
 
-//use Webmozart\Assert\Assert;
-
 class SeablastFlag
 {
     use \Nette\SmartObject;
@@ -20,21 +18,18 @@ class SeablastFlag
 
     public function activate(string $property): self
     {
-        //Assert::string($property);
         $this->flags[$property] = true;
         return $this;
     }
 
     public function deactivate(string $property): self
     {
-        //Assert::string($property);
         unset($this->flags[$property]);
         return $this;
     }
 
     public function status(string $property): bool
     {
-        //Assert::string($property);
         return array_key_exists($property, $this->flags);
     }
 }

--- a/src/SeablastFlag.php
+++ b/src/SeablastFlag.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Seablast\Seablast;
 
-use Webmozart\Assert\Assert;
+//use Webmozart\Assert\Assert;
 
 class SeablastFlag
 {
@@ -20,21 +20,21 @@ class SeablastFlag
 
     public function activate(string $property): self
     {
-        Assert::string($property);
+        //Assert::string($property);
         $this->flags[$property] = true;
         return $this;
     }
 
     public function deactivate(string $property): self
     {
-        Assert::string($property);
+        //Assert::string($property);
         unset($this->flags[$property]);
         return $this;
     }
 
     public function status(string $property): bool
     {
-        Assert::string($property);
+        //Assert::string($property);
         return array_key_exists($property, $this->flags);
     }
 }

--- a/src/SeablastModel.php
+++ b/src/SeablastModel.php
@@ -65,7 +65,7 @@ class SeablastModel
      *
      * @return stdClass
      */
-    public function getParameters()
+    public function getParameters(): stdClass
     {
         return $this->viewParameters;
     }

--- a/src/SeablastModel.php
+++ b/src/SeablastModel.php
@@ -34,6 +34,7 @@ class SeablastModel
         $this->mapping = $this->controller->mapping;
         if (isset($this->mapping['model'])) {
             $className = $this->mapping['model'];
+            /** @phpstan-ignore staticMethod.alreadyNarrowedType */
             Assert::string($className);
             Assert::true(class_exists($className), "Class {$className} does not exist.");
             $model = new $className($this->controller->getConfiguration(), $superglobals);

--- a/src/SeablastMysqli.php
+++ b/src/SeablastMysqli.php
@@ -9,6 +9,7 @@ use mysqli_result;
 use Seablast\Seablast\Exceptions\DbmsException;
 use Seablast\Seablast\Tracy\BarPanelTemplate;
 use Tracy\Debugger;
+use Tracy\Dumper;
 use Tracy\ILogger;
 
 /**
@@ -83,7 +84,7 @@ class SeablastMysqli extends mysqli
             if ($result === false) {
                 $this->databaseError = true;
                 $dbError = ['query' => $trimmedQuery, 'Err#' => $this->errno, 'Error:' => $this->error];
-                Debugger::barDump($dbError, 'Database error');
+                Debugger::barDump($dbError, 'Database error', [Dumper::TRUNCATE => 1500]); // longer than 150 chars
                 Debugger::log('Database error' . print_r($dbError, true), ILogger::ERROR);
                 $this->statementList[] = "{$this->errno}: {$this->error}";
                 $this->logQuery("{$trimmedQuery} -- {$this->errno}: {$this->error}");

--- a/src/SeablastMysqli.php
+++ b/src/SeablastMysqli.php
@@ -31,8 +31,8 @@ class SeablastMysqli extends mysqli
      * @param string $username
      * @param string $password
      * @param string $dbname
-     * @param int|null $port
-     * @param string|null $socket
+     * @param ?int $port
+     * @param ?string $socket
      * @throws DbmsException
      */
     public function __construct(
@@ -77,7 +77,7 @@ class SeablastMysqli extends mysqli
             // TODO jak NELOGOVAT hesla? Použít queryNoLog() nebo nějaká chytristika?
             $this->logQuery($trimmedQuery);
         }
-        try {    
+        try {
             $result = parent::query($trimmedQuery, $resultmode);
             $this->statementList[] = ($result === false ? 'failure => ' : '') . $trimmedQuery;
             if ($result === false) {

--- a/src/SeablastMysqli.php
+++ b/src/SeablastMysqli.php
@@ -9,6 +9,7 @@ use mysqli_result;
 use Seablast\Seablast\Exceptions\DbmsException;
 use Seablast\Seablast\Tracy\BarPanelTemplate;
 use Tracy\Debugger;
+use Tracy\ILogger;
 
 /**
  * mysqli wrapper with logging
@@ -32,7 +33,7 @@ class SeablastMysqli extends mysqli
      * @param string $dbname
      * @param int|null $port
      * @param string|null $socket
-     * @throws \Exception
+     * @throws DbmsException
      */
     public function __construct(
         string $host,
@@ -52,7 +53,7 @@ class SeablastMysqli extends mysqli
             parent::__construct($host, $username, $password, $dbname, $port, $socket);
         }
         if ($this->connect_error) {
-            throw new \Exception(
+            throw new DbmsException(
                 'Connection to database failed with error #' . $this->connect_errno . ' ' . $this->connect_error
             );
         }
@@ -70,22 +71,20 @@ class SeablastMysqli extends mysqli
     #[\ReturnTypeWillChange]
     public function query($query, $resultmode = MYSQLI_STORE_RESULT)
     {
-        try {
-            $trimmedQuery = trim($query);
-            if (!$this->isReadDataTypeQuery($trimmedQuery)) {
-                // Log queries that may change data
-                // TODO jak NELOGOVAT hesla? Použít queryNoLog() nebo nějaká chytristika?
-                $this->logQuery($query);
-            }
-            $result = parent::query($query, $resultmode);
+        $trimmedQuery = trim($query);
+        if (!$this->isReadDataTypeQuery($trimmedQuery)) {
+            // Log queries that may change data
+            // TODO jak NELOGOVAT hesla? Použít queryNoLog() nebo nějaká chytristika?
+            $this->logQuery($trimmedQuery);
+        }
+        try {    
+            $result = parent::query($trimmedQuery, $resultmode);
             $this->statementList[] = ($result === false ? 'failure => ' : '') . $trimmedQuery;
             if ($result === false) {
                 $this->databaseError = true;
-                // TODO optimize error logging
-                Debugger::barDump(
-                    ['query' => $trimmedQuery, 'Err#' => $this->errno, 'Error:' => $this->error],
-                    'Database error'
-                );
+                $dbError = ['query' => $trimmedQuery, 'Err#' => $this->errno, 'Error:' => $this->error];
+                Debugger::barDump($dbError, 'Database error');
+                Debugger::log('Database error' . print_r($dbError, true), ILogger::ERROR);
                 $this->statementList[] = "{$this->errno}: {$this->error}";
                 $this->logQuery("{$trimmedQuery} -- {$this->errno}: {$this->error}");
             }

--- a/src/SeablastMysqli.php
+++ b/src/SeablastMysqli.php
@@ -58,7 +58,8 @@ class SeablastMysqli extends mysqli
                 'Connection to database failed with error #' . $this->connect_errno . ' ' . $this->connect_error
             );
         }
-        $this->logPath = APP_DIR . '/log/query_' . date('Y-m') . '.log';
+        // Use Debugger::$logDirectory instead of APP_DIR . '/log'
+        $this->logPath = Debugger::$logDirectory . '/query_' . date('Y-m') . '.log';
     }
 
     /**

--- a/src/SeablastSetup.php
+++ b/src/SeablastSetup.php
@@ -16,9 +16,10 @@ class SeablastSetup
         // Create configuration of the app by applying configuration files in order from generic to specific
         $this->configuration = new SeablastConfiguration();
         $fileConfigurationPriority = [
-            __DIR__ . '/../conf/default.conf.php',
-            APP_DIR . '/conf/app.conf.php',
-            APP_DIR . '/conf/app.conf.local.php',
+            __DIR__ . '/../conf/default.conf.php', // default Seablast configuration
+            APP_DIR . '/vendor/seablast/auth/conf/app.conf.php', // Seablast/Auth extension configuration
+            APP_DIR . '/conf/app.conf.php', // default application configuration
+            APP_DIR . '/conf/app.conf.local.php', // configuration specific for the environment
         ];
         foreach ($fileConfigurationPriority as $confFilename) {
             $this->updateConfiguration($confFilename);

--- a/src/SeablastView.php
+++ b/src/SeablastView.php
@@ -32,7 +32,6 @@ class SeablastView
         $this->params = $this->model->getParameters();
         Debugger::barDump($this->params, 'Params for SeablastView'); // debug
         Debugger::log('Params for SeablastView: ' . print_r($this->params, true), ILogger::DEBUG);
-        error_log('Params for SeablastView: ' . print_r($this->params, true)); // debug
         $this->params->configuration = $this->model->getConfiguration();
         if (isset($this->params->redirection)) { // TODO remove this condition in higher version than 0.2
             throw new \Exception('not redirection but use redirectionUrl'); // debug deprecated

--- a/src/Tracy/BarPanelTemplate.php
+++ b/src/Tracy/BarPanelTemplate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seablast\Seablast\Tracy;
 
 use Tracy\IBarPanel;

--- a/src/Tracy/BarPanelTemplate.php
+++ b/src/Tracy/BarPanelTemplate.php
@@ -55,7 +55,7 @@ class BarPanelTemplate implements IBarPanel
         $cntTable = '';
 
         foreach ($this->panelDetails as $id => $detail) {
-            $cntTable .= '<tr><td>' . htmlspecialchars($id, ENT_QUOTES, 'UTF-8') . '</td><td>';
+            $cntTable .= '<tr><td>' . htmlspecialchars((string) $id, ENT_QUOTES, 'UTF-8') . '</td><td>';
 
             if (is_array($detail)) {
                 $cntTable .= '<table>';

--- a/src/Tracy/BarPanelTemplate.php
+++ b/src/Tracy/BarPanelTemplate.php
@@ -6,21 +6,19 @@ use Tracy\IBarPanel;
 
 /**
  * Tracy panel showing info about Template
- *
  */
 class BarPanelTemplate implements IBarPanel
 {
     use \Nette\SmartObject;
 
-    /** @var string */
-    protected $tabTitle;
-    /** @var array<mixed> */
-    protected $panelDetails;
     /** @var bool false = info, true = error */
     protected $errorPanel = false;
+    /** @var array<mixed> */
+    protected $panelDetails;
+    /** @var string */
+    protected $tabTitle;
 
     /**
-     *
      * @param string $tabTitle
      * @param array<mixed> $panelDetails
      */
@@ -52,30 +50,32 @@ class BarPanelTemplate implements IBarPanel
      */
     public function getPanel(): string
     {
-        $title = '<h1>' . htmlspecialchars($this->tabTitle) . '</h1>';
         $cntTable = '';
 
         foreach ($this->panelDetails as $id => $detail) {
-            $cntTable .= '<tr><td>' . htmlspecialchars($id) . '</td><td>';
+            $cntTable .= '<tr><td>' . htmlspecialchars($id, ENT_QUOTES, 'UTF-8') . '</td><td>';
+        
             if (is_array($detail)) {
                 $cntTable .= '<table>';
                 foreach ($detail as $k => $v) {
-                    $cntTable .= "<tr><td>" . htmlspecialchars($k) . "</td><td title='"
-                        . htmlspecialchars(print_r($v, true))
-                        . "'>" . htmlspecialchars(substr(print_r($v, true), 0, 240)) . "</td></tr>";
+                    $valueStr = htmlspecialchars(print_r($v, true), ENT_QUOTES, 'UTF-8');
+                    $cntTable .= '<tr><td>' . htmlspecialchars($k, ENT_QUOTES, 'UTF-8') . '</td><td title="'
+                        . $valueStr . '">' . mb_substr($valueStr, 0, 240, 'UTF-8') . '</td></tr>';
                 }
                 $cntTable .= '</table>';
             } else {
-                $cntTable .= htmlspecialchars(print_r($detail, true));
+                $cntTable .= htmlspecialchars(print_r($detail, true), ENT_QUOTES, 'UTF-8');
             }
+        
             $cntTable .= '</td></tr>';
         }
-
-        $content = '<div class=\"tracy-inner tracy-InfoPanel\"><table><tbody>' .
-            $cntTable .
-            '</tbody></table>* Hover over field to see its full content.</div>';
-
-        return $title . $content;
+        return
+            // title
+            '<h1>' . htmlspecialchars($this->tabTitle, ENT_QUOTES, 'UTF-8') . '</h1>'
+            // content
+            . '<div class="tracy-inner tracy-InfoPanel"><table><tbody>'
+            . $cntTable
+            . '</tbody></table>* Hover over field to see its full content.</div>';
     }
 
     /**

--- a/src/Tracy/BarPanelTemplate.php
+++ b/src/Tracy/BarPanelTemplate.php
@@ -54,7 +54,7 @@ class BarPanelTemplate implements IBarPanel
 
         foreach ($this->panelDetails as $id => $detail) {
             $cntTable .= '<tr><td>' . htmlspecialchars($id, ENT_QUOTES, 'UTF-8') . '</td><td>';
-        
+
             if (is_array($detail)) {
                 $cntTable .= '<table>';
                 foreach ($detail as $k => $v) {
@@ -66,7 +66,7 @@ class BarPanelTemplate implements IBarPanel
             } else {
                 $cntTable .= htmlspecialchars(print_r($detail, true), ENT_QUOTES, 'UTF-8');
             }
-        
+
             $cntTable .= '</td></tr>';
         }
         return

--- a/views/BlueprintWeb.latte
+++ b/views/BlueprintWeb.latte
@@ -84,5 +84,6 @@
             <p>Follow us on social media</p>
             <!-- Social media links -->
         </footer>
+        {block script}{/block} {* Note: content of block script MUST use <script></script> *}
     </body>
 </html>


### PR DESCRIPTION
### Added

- [prettier-fix](https://github.com/WorkOfStan/prettier-fix) included to fix all those `VALIDATE_something_PRETTIER` that are now crucial part of super-linter
- if [Seablast/Auth](https://github.com/WorkOfStan/seablast-auth) extension is present, use its configuration
- `{block script}{/block}` to BlueprintWeb.latte
- change of the log location enabled (single settings for Seablast\Logger, Tracy\Debugger and SeablastMysqli)

### Changed

- SeablastConfiguration::exists simplified
- updated dependencies not to refer below PHP/7.2
- SeablastMysqli::query error shows up to 1500 characters of a query that ended up with a database error (instead of truncating to the default 150 characters)

### Removed

- some Assertions removed as not needed for PHPStan/2