### PR TITLE
Correct HTTP code returned for error page. SeablastMysqli logs the user.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed` for any bugfixes
 
+### `Security` in case of vulnerabilities
+
+## [0.2.6] - 2024-12-29
+
+### Fixed
+
 - HTML output also returns HTTP codes other than 200
 
-### `Security` in case of vulnerabilities
+### Security
+
+- SeablastMysqli::setUser() injects user ID to be logged with queries
 
 ## [0.2.5] - 2024-12-20
 
@@ -217,7 +225,8 @@ PHPUnit tests ready
 - model returns knowledge()
 - a nice Under construction page
 
-[Unreleased]: https://github.com/WorkOfStan/seablast/compare/v0.2.5...HEAD?w=1
+[Unreleased]: https://github.com/WorkOfStan/seablast/compare/v0.2.6...HEAD?w=1
+[0.2.6]: https://github.com/WorkOfStan/seablast/compare/v0.2.5...v0.2.6?w=1
 [0.2.5]: https://github.com/WorkOfStan/seablast/compare/v0.2.4...v0.2.5?w=1
 [0.2.4]: https://github.com/WorkOfStan/seablast/compare/v0.2.3.5...v0.2.4?w=1
 [0.2.3.5]: https://github.com/WorkOfStan/seablast/compare/v0.2.3.4...v0.2.3.5?w=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed` for any bugfixes
 
+- HTML output also returns HTTP codes other than 200
+
 ### `Security` in case of vulnerabilities
 
 ## [0.2.5] - 2024-12-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added` for new features
 
 - TableViewModel for admin.latte
-- GenericRestApiJsonModel::response(int $httpCode, string $message): object as a simple API response
 
 ### `Changed` for changes in existing functionality
 
@@ -24,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.6] - 2024-12-29
 
+Correct HTTP code returned for error page. SeablastMysqli logs the user.
+
+### Added
+
+- GenericRestApiJsonModel::response(int $httpCode, string $message): object as a simple API response
+
 ### Fixed
 
 - HTML output also returns HTTP codes other than 200
@@ -33,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SeablastMysqli::setUser() injects user ID to be logged with queries
 
 ## [0.2.5] - 2024-12-20
+
+If Seablast/Auth extension is present, use its configuration. Log location change enabled.
 
 ### Added
 
@@ -55,6 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - some Assertions removed as not needed for PHPStan/2
 
 ## [0.2.4] - 2024-08-04
+
+Tracy logs through Seablast/logger, which provides verbosity control.
 
 ### Added
 
@@ -84,6 +93,8 @@ PHPUnit tests ready
 - SeablastController::applyConfiguration divided to part called only once before session starts, and part that can be called repeatedly (e.g. for PHPUnit)
 
 ## [0.2.3.4] - 2024-05-30
+
+SeablastConstant::SB_PHINX_ENVIRONMENT to override `$phinx['environments']['default_environment']`
 
 ### Added
 
@@ -119,6 +130,8 @@ PHPUnit tests ready
 
 ## [0.2.3] - 2024-03-03
 
+SeablastConstant::USER_ID and SeablastConstant::USER_GROUPS in SeablastConfiguration
+
 ### Added
 
 - table prefix (phinx) available through SB:phinx:table_prefix OR dbmsTablePrefix()
@@ -142,6 +155,8 @@ PHPUnit tests ready
 
 ## [0.2.1] - 2024-02-03
 
+Role-Based Access Control
+
 ### Added
 
 - `SeablastConstant::SB_SMTP_` default parameters
@@ -164,6 +179,8 @@ PHPUnit tests ready
 
 ## [0.2] - 2024-01-27
 
+CSRF, model returns object (not array anymore), directories are in plural
+
 ### Added
 
 - show HTTP code error Tracy BarPanel
@@ -181,6 +198,8 @@ PHPUnit tests ready
 - symfony/security-csrf component generates CSRF tokens (always checked if GenericRestApiJsonModel is extended)
 
 ## [0.1.1] - 2024-01-12
+
+SeablastMysqli error logging improved, HTTPS identified
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added` for new features
 
 - TableViewModel for admin.latte
+- GenericRestApiJsonModel::response(int $httpCode, string $message): object as a simple API response
 
 ### `Changed` for changes in existing functionality
 

--- a/src/Apis/GenericRestApiJsonModel.php
+++ b/src/Apis/GenericRestApiJsonModel.php
@@ -76,12 +76,7 @@ class GenericRestApiJsonModel implements SeablastModelInterface
          *
          */
         // if ($this->status < 400) {$this->executeBusinessLogic();} // TODO move to SBdist
-        return (object) [
-                'httpCode' => $this->httpCode,
-                'rest' => (object) [
-                    'message' => $this->message,
-                ]
-        ];
+        return self::response($this->httpCode, $this->message);
     }
 
     /**
@@ -137,6 +132,24 @@ class GenericRestApiJsonModel implements SeablastModelInterface
             return;
         }
     }
+
+    /**
+     * Simple API response.
+     *
+     * @param int $httpCode
+     * @param string $message
+     * @return object
+     */
+    protected static function response(int $httpCode, string $message): object
+    {
+        return (object) [
+                'httpCode' => $httpCode,
+                'rest' => (object) [
+                    'message' => $message,
+                ]
+        ];
+    }
+
     // todo example to be used in SBdist
     /* private function executeBusinessLogic()
       {

--- a/src/Apis/GenericRestApiJsonModel.php
+++ b/src/Apis/GenericRestApiJsonModel.php
@@ -138,9 +138,9 @@ class GenericRestApiJsonModel implements SeablastModelInterface
      *
      * @param int $httpCode
      * @param string $message
-     * @return object
+     * @return stdClass
      */
-    protected static function response(int $httpCode, string $message): object
+    protected static function response(int $httpCode, string $message): stdClass
     {
         return (object) [
                 'httpCode' => $httpCode,

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -422,6 +422,7 @@ class SeablastController
             Debugger::barDump('User is authenticated');
             // Specific role expected, if not authorized => 403
             $roleIds = explode(',', $this->mapping['roleIds']);
+            // TODO in_array comparison is loose, so even 2 equals " 2", but explode to integers would be safer
             Debugger::barDump($roleIds, 'RoleIds allowed');
             // Read the current user's role from the configuration object
             if (!in_array($this->configuration->getInt(SeablastConstant::USER_ROLE_ID), $roleIds)) {

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -397,6 +397,7 @@ class SeablastController
                 if (!is_null($this->logger)) {
                     $this->logger->setUser($this->identity->getUserId());
                 }
+                $this->configuration->dbms()->setUser($this->identity->getUserId());
             }
         }
         // Authenticate: RBAC (Role-Based Access Control)

--- a/src/SeablastMysqli.php
+++ b/src/SeablastMysqli.php
@@ -141,7 +141,8 @@ class SeablastMysqli extends mysqli
     {
         //mb_ereg_replace does not destroy multi-byte characters such as character Č
         error_log(
-            mb_ereg_replace("\r\n|\r|\n", ' ', $query) . ' -- [' . date('Y-m-d H:i:s') . '] [' . $this->user . ']' . PHP_EOL,
+            mb_ereg_replace("\r\n|\r|\n", ' ', $query) . ' -- [' . date('Y-m-d H:i:s') . '] [' . $this->user . ']'
+            . PHP_EOL,
             3,
             $this->logPath
         );

--- a/src/SeablastMysqli.php
+++ b/src/SeablastMysqli.php
@@ -13,7 +13,9 @@ use Tracy\Dumper;
 use Tracy\ILogger;
 
 /**
- * mysqli wrapper with logging
+ * MySQLi wrapper with logging.
+ *
+ * setUser() injects user ID to be logged with queries
  * TODO: explore logging of prepared statements
  */
 class SeablastMysqli extends mysqli
@@ -26,6 +28,8 @@ class SeablastMysqli extends mysqli
     private $logPath;
     /** @var string[] For Tracy Bar Panel. */
     private $statementList = [];
+    /** @var string */
+    private $user = 'unidentified';
 
     /**
      * @param string $host
@@ -137,10 +141,22 @@ class SeablastMysqli extends mysqli
     {
         //mb_ereg_replace does not destroy multi-byte characters such as character Č
         error_log(
-            mb_ereg_replace("\r\n|\r|\n", ' ', $query) . ' -- [' . date('Y-m-d H:i:s') . ']' . PHP_EOL,
+            mb_ereg_replace("\r\n|\r|\n", ' ', $query) . ' -- [' . date('Y-m-d H:i:s') . '] [' . $this->user . ']' . PHP_EOL,
             3,
             $this->logPath
         );
+    }
+
+    /**
+     * DI setter.
+     *
+     * @param int|string $user
+     *
+     * @return void
+     */
+    public function setUser($user): void
+    {
+        $this->user = (string) $user;
     }
 
     /**

--- a/src/SeablastView.php
+++ b/src/SeablastView.php
@@ -118,6 +118,17 @@ class SeablastView
             . $templatePath . ' nor in library'); // TODO improve the error message
     }
 
+    private function httpResponseCode(): void
+    {
+        if (isset($this->params->httpCode) && is_scalar($this->params->httpCode)) {
+            // accepts HTTP codes 100-599 even though some of them might not be defined
+            if ((int) $this->params->httpCode < 100 || (int) $this->params->httpCode > 599) {
+                throw new UnknownHttpCodeException('Unknown HTTP code: ' . (int) $this->params->httpCode);
+            }
+            http_response_code((int) $this->params->httpCode); // Send the status code
+        }
+    }
+
     /**
      * Outputs the given data as JSON.
      *
@@ -133,13 +144,7 @@ class SeablastView
         if (!$this->model->getConfiguration()->flag->status(SeablastConstant::FLAG_DEBUG_JSON)) {
             header('Content-Type: application/json; charset=utf-8'); //the flag turns-off this line
         }
-        if (isset($this->params->httpCode) && is_scalar($this->params->httpCode)) {
-            // accepts HTTP codes 100-599 even though some of them might not be defined
-            if ((int) $this->params->httpCode < 100 || (int) $this->params->httpCode > 599) {
-                throw new UnknownHttpCodeException('Unknown HTTP code: ' . (int) $this->params->httpCode);
-            }
-            http_response_code((int) $this->params->httpCode); // Send the status code
-        }
+        $this->httpResponseCode();
         $result = json_encode($data2json);
         Assert::string($result);
         echo($result);
@@ -152,6 +157,7 @@ class SeablastView
      */
     private function renderLatte(): void
     {
+        $this->httpResponseCode();
         $latte = new \Latte\Engine();
 
         // Maybe only for PHP8+


### PR DESCRIPTION
### Added

- GenericRestApiJsonModel::response(int $httpCode, string $message): object as a simple API response

### Fixed

- HTML output also returns HTTP codes other than 200

### Security

- SeablastMysqli::setUser() injects user ID to be logged with queries