### PR TITLE
Strict versions of database adapter calls.

### DIFF
--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - name: Invoke the PHPCS check and PHPCBF fix
         # Use the latest commit in the main branch.
-        uses: WorkOfStan/phpcs-fix@feature/notice-commit
+        uses: WorkOfStan/phpcs-fix@v1.0.1
         with:
           commit-changes: true
           php-version: "8.2"

--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - name: Invoke the PHPCS check and PHPCBF fix
         # Use the latest commit in the main branch.
-        uses: WorkOfStan/phpcs-fix@v1.0.0
+        uses: WorkOfStan/phpcs-fix@feature/notice-commit
         with:
           commit-changes: true
           php-version: "8.2"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added` for new features
 
 - TableViewModel for admin.latte
+- SeablastMysqli::prepareStrict throws DbmsException in case of failure
+- SeablastPdo::prepareStrict throws DbmsException in case of failure
 
 ### `Changed` for changes in existing functionality
 
 ### `Deprecated` for soon-to-be removed features
+
+- SeablastConfiguration::dbms() - use SeablastConfiguration::mysqli() instead.
 
 ### `Removed` for now removed features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.8] - 2025-02-09
 
+Strict versions of database adapter calls.
+
 ### Added
 
 - SeablastMysqli::prepareStrict throws DbmsException in case of failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,20 +10,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added` for new features
 
 - TableViewModel for admin.latte
-- SeablastMysqli::prepareStrict throws DbmsException in case of failure
-- SeablastPdo::prepareStrict throws DbmsException in case of failure
 
 ### `Changed` for changes in existing functionality
 
 ### `Deprecated` for soon-to-be removed features
-
-- SeablastConfiguration::dbms() - use SeablastConfiguration::mysqli() instead.
 
 ### `Removed` for now removed features
 
 ### `Fixed` for any bugfixes
 
 ### `Security` in case of vulnerabilities
+
+## [0.2.8] - 2025-02-09
+
+### Added
+
+- SeablastMysqli::prepareStrict throws DbmsException in case of failure
+- SeablastPdo::prepareStrict and SeablastPdo::queryStrict throw DbmsException in case of failure
+- SeablastConfiguration::mysqli() as replacement for a temporary alias SeablastConfiguration::dbms()
+- SeablastConfiguration::mysqliStatus() as replacement for a temporary alias SeablastConfiguration::dbmsStatus()
+
+### Deprecated
+
+- SeablastConfiguration::dbms() - use SeablastConfiguration::mysqli() instead.
+- SeablastConfiguration::dbmsStatus() - use SeablastConfiguration::mysqliStatus() instead.
 
 ## [0.2.7] - 2025-02-01
 
@@ -268,7 +278,8 @@ SeablastMysqli error logging improved, HTTPS identified
 - model returns knowledge()
 - a nice Under construction page
 
-[Unreleased]: https://github.com/WorkOfStan/seablast/compare/v0.2.7...HEAD?w=1
+[Unreleased]: https://github.com/WorkOfStan/seablast/compare/v0.2.8...HEAD?w=1
+[0.2.8]: https://github.com/WorkOfStan/seablast/compare/v0.2.7...v0.2.8?w=1
 [0.2.7]: https://github.com/WorkOfStan/seablast/compare/v0.2.6...v0.2.7?w=1
 [0.2.6]: https://github.com/WorkOfStan/seablast/compare/v0.2.5...v0.2.6?w=1
 [0.2.5]: https://github.com/WorkOfStan/seablast/compare/v0.2.4...v0.2.5?w=1

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The framework takes care of logs, database, multiple languages, user friendly HT
 - if Seablast/Auth extension is present, use its configuration
 - everything can be overriden in the web app's `conf/app.conf.php` or even in its local deployment `conf/app.conf.local.php`
 - set the default phinx environment in the phinx configuration: `['environments']['default_environment']`
-- the default `log` directory (both for SeablastMysqli query.log and Debugger::log()) can be changed as follows `->setString(SeablastConstant::SB_LOG_DIRECTORY, APP_DIR . '/log')`
+- the default `log` directory (both for SeablastMysqli/SeablastPdo query.log and Debugger::log()) can be changed as follows `->setString(SeablastConstant::SB_LOG_DIRECTORY, APP_DIR . '/log')`
 
 ## Model
 
@@ -40,6 +40,10 @@ SeablastConstant::APP_MAPPING = route => [
     'roleIds' => '1,2', // comma delimited roleIds permitted to access the route,
 ]
 ```
+
+## Database adapters
+
+SeablastConfiguration gives you access to MySQLi adapter through mysqli() method and PDO adapter through pdo() method.
 
 ## Authentication and authorisation
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ SeablastConstant::APP_MAPPING = route => [
 
 ## Database adapters
 
-SeablastConfiguration gives you access to MySQLi adapter through mysqli() method and PDO adapter through pdo() method.
+SeablastConfiguration provides access to MySQLi adapter through mysqli() method and PDO adapter through pdo() method.
 
 ## Authentication and authorisation
 

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,3 @@ All planned changes to this project are documented in this file.
 - 231207, nice 404 (adapt redirection.latte to special operational pages layout)
 - 231229, UI for db administration
 - 2402010004: Mit.js mit.css with sb const update by sbView
-
-## Governance
-
-- 231206, cut Latte out of the core Seablast to be used as Seablast/render-latte

--- a/Test/SeablastConfigurationTest.php
+++ b/Test/SeablastConfigurationTest.php
@@ -35,7 +35,7 @@ class SeablastConfigurationTest extends TestCase
 
     public function testDbmsReturnsSeablastMysqliInstance(): void
     {
-        $this->assertInstanceOf(SeablastMysqli::class, $this->configuration->dbms());
+        $this->assertInstanceOf(SeablastMysqli::class, $this->configuration->mysqli());
     }
 
 //    public function testDbmsThrowsExceptionIfNoConnection(): void
@@ -50,7 +50,7 @@ class SeablastConfigurationTest extends TestCase
 ////            ->method('dbmsStatus')
 ////            ->willReturn(false);
 //
-//        $this->configuration->dbms();
+//        $this->configuration->mysqli();
 //    }
 
 //    public function testDbmsTablePrefix()

--- a/Test/SeablastMysqliTest.php
+++ b/Test/SeablastMysqliTest.php
@@ -39,7 +39,7 @@ class SeablastMysqliTest extends TestCase
         $configuration->setInt(SeablastConstant::SB_LOGGING_LEVEL, 5);
         $configuration->setString(SeablastConstant::SB_PHINX_ENVIRONMENT, 'testing'); // so that the database test works
 
-        $this->mysqli = $configuration->dbms();
+        $this->mysqli = $configuration->mysqli();
     }
 
     public function testConstructorSuccess(): void

--- a/conf/default.conf.php
+++ b/conf/default.conf.php
@@ -61,9 +61,9 @@ return static function (SeablastConfiguration $SBConfig): void {
         ->setInt(SeablastConstant::SB_SMTP_PORT, 25)
         ->setString(SeablastConstant::SB_SMTP_USERNAME, '')
         ->setString(SeablastConstant::SB_SMTP_PASSWORD, '')
-        // User roles according to Seablast/Auth
-     ->setInt(SeablastConstant::USER_ROLE_ADMIN, 1)
-    ->setInt(SeablastConstant::USER_ROLE_EDITOR, 2)
-    ->setInt(SeablastConstant::USER_ROLE_USER, 3)
+        // User roles according to Seablast/Auth // TODO get rid of these?
+        ->setInt(SeablastConstant::USER_ROLE_ADMIN, 1)
+        ->setInt(SeablastConstant::USER_ROLE_EDITOR, 2)
+        ->setInt(SeablastConstant::USER_ROLE_USER, 3)
     ;
 };

--- a/src/SeablastConfiguration.php
+++ b/src/SeablastConfiguration.php
@@ -43,22 +43,16 @@ class SeablastConfiguration
     }
 
     /**
-     * Access to database with lazy initialization.
+     * Access to database using MySQLi adapter with lazy initialization.
      *
-     * todo alias for mysqli and this deprecated
-     *
+     * @deprecated 0.2.8 Use {@see mysqli()} instead.
      * @return SeablastMysqli
      */
     public function dbms(): SeablastMysqli
     {
-        //Lazy initialisation
-        if (!$this->dbmsStatus()) {
-            Debugger::barDump('Creating MySQLi database connection');
-            $this->mysqliCreate();
-        }
-        Assert::object($this->mysqli);
-        Assert::isAOf($this->mysqli, '\Seablast\Seablast\SeablastMysqli');
-        return $this->mysqli;
+        Debugger::barDump('Deprecated dbms(). Use mysqli() instead.');
+        Debugger::log('Deprecated dbms(). Use mysqli() instead.', \Tracy\ILogger::INFO);
+        return $this->mysqli();
     }
 
     /**
@@ -229,6 +223,23 @@ class SeablastConfiguration
         return $this->optionsString[$property];
     }
 
+    /**
+     * Access to database using MySQLi adapter with lazy initialization.
+     *
+     * @return SeablastMysqli
+     */
+    public function mysqli(): SeablastMysqli
+    {
+        //Lazy initialisation
+        if (!$this->dbmsStatus()) {
+            Debugger::barDump('Creating MySQLi database connection');
+            $this->mysqliCreate();
+        }
+        Assert::object($this->mysqli);
+        Assert::isAOf($this->mysqli, '\Seablast\Seablast\SeablastMysqli');
+        return $this->mysqli;
+    }
+    
     /**
      * Creates a database connection and sets up charset.
      *

--- a/src/SeablastConfiguration.php
+++ b/src/SeablastConfiguration.php
@@ -121,12 +121,13 @@ class SeablastConfiguration
      *
      * So that the SQL Bar Panel is not requested in vain.
      *
-     todo alias for mysqliStatus and deprecated
-
+     * @deprecated 0.2.8 Use {@see mysqliStatus()} instead.
      * @return bool
      */
     public function dbmsStatus(): bool
     {
+        Debugger::barDump('Deprecated dbmsStatus(). Use mysqliStatus() instead.');
+        Debugger::log('Deprecated dbmsStatus(). Use mysqliStatus() instead.', \Tracy\ILogger::INFO);
         return $this->mysqli instanceof \mysqli;
     }
 
@@ -229,9 +230,9 @@ class SeablastConfiguration
      * @return SeablastMysqli
      */
     public function mysqli(): SeablastMysqli
-    {
+    {    
         //Lazy initialisation
-        if (!$this->dbmsStatus()) {
+        if (!$this->mysqliStatus()) {
             Debugger::barDump('Creating MySQLi database connection');
             $this->mysqliCreate();
         }
@@ -266,6 +267,18 @@ class SeablastConfiguration
         if (!is_null($this->user)) {
             $this->mysqli->setUser($this->user);
         }
+    }
+
+    /**
+     * Returns true if connected, false otherwise.
+     *
+     * So that the SQL Bar Panel is not requested in vain.
+     *
+     * @return bool
+     */
+    public function mysqliStatus(): bool
+    {
+        return $this->mysqli instanceof \mysqli;
     }
 
     /**
@@ -402,8 +415,8 @@ class SeablastConfiguration
     {
         $this->user = (string) $user;
         // if mysqli or pdo then setUser
-        if ($this->dbmsStatus()) {
-            $this->dbms()->setUser($this->user);
+        if ($this->mysqliStatus()) {
+            $this->mysqli()->setUser($this->user);
         }
         if ($this->pdoStatus()) {
             $this->pdo()->setUser($this->user);
@@ -418,8 +431,8 @@ class SeablastConfiguration
     public function showSqlBarPanel(): void
     {
         // if mysqli or pdo then showSqlBarPanel
-        if ($this->dbmsStatus()) {
-            $this->dbms()->showSqlBarPanel();
+        if ($this->mysqliStatus()) {
+            $this->mysqli()->showSqlBarPanel();
         }
         if ($this->pdoStatus()) {
             $this->pdo()->showSqlBarPanel();

--- a/src/SeablastConfiguration.php
+++ b/src/SeablastConfiguration.php
@@ -16,11 +16,11 @@ class SeablastConfiguration
 {
     use \Nette\SmartObject;
 
-    /** @var ?string */
+    /** @var string|null */
     private $connectionTablePrefix = null;
     /** @var SeablastFlag */
     public $flag;
-    /** @var ?SeablastMysqli */
+    /** @var SeablastMysqli|null */
     private $mysqli = null;
     /** @var array<array<string[]>> */
     private $optionsArrayArrayString = [];
@@ -32,7 +32,7 @@ class SeablastConfiguration
     private $optionsInt = [];
     /** @var string[] */
     private $optionsString = [];
-    /** @var ?SeablastPdo */
+    /** @var SeablastPdo|null */
     private $pdo = null;
     /** @var string|null for db logging */
     private $user = null;

--- a/src/SeablastConfiguration.php
+++ b/src/SeablastConfiguration.php
@@ -270,7 +270,7 @@ class SeablastConfiguration
     }
 
     /**
-     * Returns true if connected, false otherwise.
+     * Returns true if mysqli adapter connected, false otherwise.
      *
      * So that the SQL Bar Panel is not requested in vain.
      *
@@ -325,7 +325,7 @@ class SeablastConfiguration
     }
 
     /**
-     * Returns true if connected, false otherwise.
+     * Returns true if PDO adapter connected, false otherwise.
      *
      * So that the SQL Bar Panel is not requested in vain.
      *

--- a/src/SeablastConfiguration.php
+++ b/src/SeablastConfiguration.php
@@ -239,7 +239,7 @@ class SeablastConfiguration
         Assert::isAOf($this->mysqli, '\Seablast\Seablast\SeablastMysqli');
         return $this->mysqli;
     }
-    
+
     /**
      * Creates a database connection and sets up charset.
      *

--- a/src/SeablastConfiguration.php
+++ b/src/SeablastConfiguration.php
@@ -230,7 +230,7 @@ class SeablastConfiguration
      * @return SeablastMysqli
      */
     public function mysqli(): SeablastMysqli
-    {    
+    {
         //Lazy initialisation
         if (!$this->mysqliStatus()) {
             Debugger::barDump('Creating MySQLi database connection');

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -20,9 +20,9 @@ class SeablastController
 
     /** @var SeablastConfiguration */
     private $configuration;
-    /** @var ?IdentityManagerInterface */
+    /** @var IdentityManagerInterface|null */
     private $identity = null;
-    /** @var ?Logger */
+    /** @var Logger|null */
     private $logger = null;
     /** @var string[] mapping of URL to processing */
     public $mapping;
@@ -30,7 +30,7 @@ class SeablastController
     private $scriptName;
     /** @var Superglobals */
     private $superglobals;
-    /** @var ?ILogger */
+    /** @var ILogger|null */
     private $tracyLogger = null;
     /** @var string */
     private $uriPath = '';

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -381,7 +381,7 @@ class SeablastController
         if ($this->configuration->exists(SeablastConstant::SB_IDENTITY_MANAGER)) {
             $identityManager = $this->configuration->getString(SeablastConstant::SB_IDENTITY_MANAGER);
             /* @phpstan-ignore-next-line Property $identity does not accept object. */
-            $this->identity = new $identityManager($this->configuration->dbms());
+            $this->identity = new $identityManager($this->configuration->mysqli());
             if (method_exists($this->identity, 'setTablePrefix')) {
                 $this->identity->setTablePrefix($this->configuration->dbmsTablePrefix());
             }

--- a/src/SeablastPdo.php
+++ b/src/SeablastPdo.php
@@ -182,7 +182,7 @@ class SeablastPdo extends PDO
      */
     public function queryStrict(string $query, ?int $fetchMode = null, ...$fetchModeArgs)
     {
-      //  $trimmedQuery = trim($query);
+        $trimmedQuery = trim($query);
      //   if (!$this->isReadDataTypeQuery($trimmedQuery)) {
       //      $this->logQuery($trimmedQuery);
      //   }

--- a/src/SeablastPdo.php
+++ b/src/SeablastPdo.php
@@ -188,28 +188,30 @@ class SeablastPdo extends PDO
      //   }
       //  try {
             // Execute the query based on the presence of fetchMode and fetchModeArgs
-            if (!empty($fetchModeArgs) && !is_null($fetchMode)) {
-                // Spread the fetchModeArgs to pass them as individual arguments
-                $stmt = $this->query($trimmedQuery, $fetchMode, ...$fetchModeArgs);
-            } elseif (!is_null($fetchMode)) {
-                // Only fetchMode is provided
-                $stmt = $this->query($trimmedQuery, $fetchMode);
-            } else {
-                // Neither fetchMode nor fetchModeArgs are provided
-                $stmt = $this->query($trimmedQuery);
-            }
+        if (!empty($fetchModeArgs) && !is_null($fetchMode)) {
+            // Spread the fetchModeArgs to pass them as individual arguments
+            $stmt = $this->query($trimmedQuery, $fetchMode, ...$fetchModeArgs);
+        } elseif (!is_null($fetchMode)) {
+            // Only fetchMode is provided
+            $stmt = $this->query($trimmedQuery, $fetchMode);
+        } else {
+            // Neither fetchMode nor fetchModeArgs are provided
+            $stmt = $this->query($trimmedQuery);
+        }
 
         //    $this->addStatement(true, $trimmedQuery);
-            
+
         if ($stmt === false) {
          ////   $this->addStatement(false, $trimmedQuery); // todo isn't it duplicit error report?
-            Debugger::barDump(['arguments'=> func_get_args(),
+            Debugger::barDump(
+                ['arguments' => func_get_args(),
                       'errorCode' =>        $this->errorCode(),
-                     'errorInfo' =>    $this->errorInfo()],     
-                              'Query failed');
+                     'errorInfo' =>    $this->errorInfo()],
+                'Query failed'
+            );
             throw new DbmsException("Query failed.", (int) $this->errorCode());
         }
-return $stmt;
+        return $stmt;
     }
 
     /**

--- a/src/SeablastPdo.php
+++ b/src/SeablastPdo.php
@@ -183,11 +183,7 @@ class SeablastPdo extends PDO
     public function queryStrict(string $query, ?int $fetchMode = null, ...$fetchModeArgs)
     {
         $trimmedQuery = trim($query);
-     //   if (!$this->isReadDataTypeQuery($trimmedQuery)) {
-      //      $this->logQuery($trimmedQuery);
-     //   }
-      //  try {
-            // Execute the query based on the presence of fetchMode and fetchModeArgs
+        // Execute the query based on the presence of fetchMode and fetchModeArgs
         if (!empty($fetchModeArgs) && !is_null($fetchMode)) {
             // Spread the fetchModeArgs to pass them as individual arguments
             $stmt = $this->query($trimmedQuery, $fetchMode, ...$fetchModeArgs);
@@ -199,14 +195,13 @@ class SeablastPdo extends PDO
             $stmt = $this->query($trimmedQuery);
         }
 
-        //    $this->addStatement(true, $trimmedQuery);
-
         if ($stmt === false) {
-         ////   $this->addStatement(false, $trimmedQuery); // todo isn't it duplicit error report?
             Debugger::barDump(
-                ['arguments' => func_get_args(),
-                      'errorCode' =>        $this->errorCode(),
-                     'errorInfo' =>    $this->errorInfo()],
+                [
+                    'arguments' => func_get_args(),
+                    'errorCode' => $this->errorCode(),
+                    'errorInfo' => $this->errorInfo()
+                ],
                 'Query failed'
             );
             throw new DbmsException("Query failed.", (int) $this->errorCode());

--- a/src/SeablastPdo.php
+++ b/src/SeablastPdo.php
@@ -118,6 +118,24 @@ class SeablastPdo extends PDO
     }
 
     /**
+     * Prepares a statement and logs the query. Throws an exception in case of SQL statement failure.
+     *
+     * @param string $query but mixed in PHP/7
+     * @param array<scalar> $options but mixed in PHP/7
+     * @return PDOStatement
+     * @throws DbmsException
+     */
+    public function prepareStrict($query, $options = [])
+    {
+        $stmt = $this->prepare($query, $options);
+        if ($stmt === false) {
+            // Database Tracy BarPanel is displayed in try-catch in SeablastView
+            throw new DbmsException('PDO prepare statement failed');
+        }
+        return $stmt;
+    }
+
+    /**
      * Executes a query and logs it.
      *
      * @param string $query

--- a/src/SeablastPdo.php
+++ b/src/SeablastPdo.php
@@ -163,12 +163,53 @@ class SeablastPdo extends PDO
                 $stmt = parent::query($trimmedQuery);
             }
 
-            $this->addStatement(true, $trimmedQuery);
+            $this->addStatement((bool) $stmt, $trimmedQuery);
             return $stmt;
         } catch (PDOException $e) {
             $this->addStatement(false, $trimmedQuery, $e->getMessage());
             throw new DbmsException("Query failed: " . $e->getMessage(), (int)$e->getCode(), $e);
         }
+    }
+
+    /**
+     * Executes a query and logs it. Throws an exception in case of SQL statement failure.
+     *
+     * @param string $query
+     * @param int|null $fetchMode
+     * @param mixed ...$fetchModeArgs
+     * @return PDOStatement
+     * @throws DbmsException
+     */
+    public function queryStrict(string $query, ?int $fetchMode = null, ...$fetchModeArgs)
+    {
+      //  $trimmedQuery = trim($query);
+     //   if (!$this->isReadDataTypeQuery($trimmedQuery)) {
+      //      $this->logQuery($trimmedQuery);
+     //   }
+      //  try {
+            // Execute the query based on the presence of fetchMode and fetchModeArgs
+            if (!empty($fetchModeArgs) && !is_null($fetchMode)) {
+                // Spread the fetchModeArgs to pass them as individual arguments
+                $stmt = $this->query($trimmedQuery, $fetchMode, ...$fetchModeArgs);
+            } elseif (!is_null($fetchMode)) {
+                // Only fetchMode is provided
+                $stmt = $this->query($trimmedQuery, $fetchMode);
+            } else {
+                // Neither fetchMode nor fetchModeArgs are provided
+                $stmt = $this->query($trimmedQuery);
+            }
+
+        //    $this->addStatement(true, $trimmedQuery);
+            
+        if ($stmt === false) {
+         ////   $this->addStatement(false, $trimmedQuery); // todo isn't it duplicit error report?
+            Debugger::barDump(['arguments'=> func_get_args(),
+                      'errorCode' =>        $this->errorCode(),
+                     'errorInfo' =>    $this->errorInfo()],     
+                              'Query failed');
+            throw new DbmsException("Query failed.", (int) $this->errorCode());
+        }
+return $stmt;
     }
 
     /**


### PR DESCRIPTION
### Added

- SeablastMysqli::prepareStrict throws DbmsException in case of failure
- SeablastPdo::prepareStrict and SeablastPdo::queryStrict throw DbmsException in case of failure
- SeablastConfiguration::mysqli() as replacement for a temporary alias SeablastConfiguration::dbms()
- SeablastConfiguration::mysqliStatus() as replacement for a temporary alias SeablastConfiguration::dbmsStatus()

### Deprecated

- SeablastConfiguration::dbms() - use SeablastConfiguration::mysqli() instead.
- SeablastConfiguration::dbmsStatus() - use SeablastConfiguration::mysqliStatus() instead.