### PR TITLE
chore: PHP/8.4 support added

### DIFF
--- a/.github/workflows/overtrue-phplint.yml
+++ b/.github/workflows/overtrue-phplint.yml
@@ -15,4 +15,4 @@ permissions:
 
 jobs:
   call-workflow:
-    uses: WorkOfStan/seablast-actions/.github/workflows/overtrue-phplint.yml@v0.2.1
+    uses: WorkOfStan/seablast-actions/.github/workflows/overtrue-phplint.yml@v0.2.3

--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -27,7 +27,7 @@ jobs:
     uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.2
     with:
       # JSON
-      php-version: '["7.2", "7.3", "7.4", "8.1", "8.2", "8.3", "8.4"]'
+      php-version: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       # OPTIONAL path with the default database configuration
       phinx-config: "./conf/phinx.dist.php"
       # OPTIONAL path where the app code is looking for the database configuration

--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -24,10 +24,10 @@ permissions:
 jobs:
   # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.
   php-composer-unit-stan:
-    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.1
+    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.2
     with:
       # JSON
-      php-version: '["7.2", "7.3", "7.4", "8.1", "8.2", "8.3"]'
+      php-version: '["7.2", "7.3", "7.4", "8.1", "8.2", "8.3", "8.4"]'
       # OPTIONAL path with the default database configuration
       phinx-config: "./conf/phinx.dist.php"
       # OPTIONAL path where the app code is looking for the database configuration
@@ -44,7 +44,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Invoke the Prettier fix
-        uses: WorkOfStan/prettier-fix@v1.1.1
+        uses: WorkOfStan/prettier-fix@v1.1.3
         with:
           commit-changes: true
 
@@ -66,6 +66,6 @@ jobs:
 
   super-linter:
     needs: phpcs-phpcbf
-    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.1
+    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.2
     with:
       runs-on: "ubuntu-latest"

--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.
   php-composer-unit-stan:
-    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.2
+    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.3
     with:
       # JSON
       php-version: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
@@ -66,6 +66,6 @@ jobs:
 
   super-linter:
     needs: phpcs-phpcbf
-    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.2
+    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.3
     with:
       runs-on: "ubuntu-latest"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added` for new features
 
 - TableViewModel for admin.latte
-- GitHub test PHP/8.4
 
 ### `Changed` for changes in existing functionality
-
-- mapping['roleIds'] exploded into array of integers is safer even thou in_array comparison is loose (so 2 equals " 2")
 
 ### `Deprecated` for soon-to-be removed features
 
@@ -23,6 +20,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed` for any bugfixes
 
 ### `Security` in case of vulnerabilities
+
+## [0.2.9] - 2025-03-09
+
+### Added
+
+- support for PHP/8.4, including GitHub tests
+- blast.sh - Management script for deployment and development of a Seablast application
+
+### Changed
+
+- mapping['roleIds'] exploded into array of integers is safer even thou in_array comparison is loose (so 2 equals " 2")
 
 ## [0.2.8] - 2025-02-09
 
@@ -283,7 +291,8 @@ SeablastMysqli error logging improved, HTTPS identified
 - model returns knowledge()
 - a nice Under construction page
 
-[Unreleased]: https://github.com/WorkOfStan/seablast/compare/v0.2.8...HEAD?w=1
+[Unreleased]: https://github.com/WorkOfStan/seablast/compare/v0.2.9...HEAD?w=1
+[0.2.9]: https://github.com/WorkOfStan/seablast/compare/v0.2.8...v0.2.9?w=1
 [0.2.8]: https://github.com/WorkOfStan/seablast/compare/v0.2.7...v0.2.8?w=1
 [0.2.7]: https://github.com/WorkOfStan/seablast/compare/v0.2.6...v0.2.7?w=1
 [0.2.6]: https://github.com/WorkOfStan/seablast/compare/v0.2.5...v0.2.6?w=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.9] - 2025-03-09
 
+chore: PHP/8.4 support added
+
 ### Added
 
 - support for PHP/8.4, including GitHub tests
+- support for PHP/8.0 added again
 - blast.sh - Management script for deployment and development of a Seablast application
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added` for new features
 
 - TableViewModel for admin.latte
+- GitHub test PHP/8.4
 
 ### `Changed` for changes in existing functionality
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed` for changes in existing functionality
 
+- mapping['roleIds'] exploded into array of integers is safer even thou in_array comparison is loose (so 2 equals " 2")
+
 ### `Deprecated` for soon-to-be removed features
 
 ### `Removed` for now removed features

--- a/README.md
+++ b/README.md
@@ -81,3 +81,7 @@ All JSON calls and form submits MUST contain `csrfToken` handed over in the `$cs
 ## Testing
 
 The PHPUnit tests use the database configuration from `./conf/phinx.local.php`, so the library require-dev Phinx, ensuring PHPUnit tests work on GitHub as well.
+
+## Development notes
+
+`./blast.sh phpstan` runs PHPStan to test the repo. It can also be called ./vendor/seablast/seablast/blast.sh from a Seablast application as a management script for deployment and development.

--- a/README.md
+++ b/README.md
@@ -84,4 +84,5 @@ The PHPUnit tests use the database configuration from `./conf/phinx.local.php`, 
 
 ## Development notes
 
-`./blast.sh phpstan` runs PHPStan to test the repo. It can also be called ./vendor/seablast/seablast/blast.sh from a Seablast application as a management script for deployment and development.
+`./blast.sh phpstan` runs PHPStan to test the repository.
+It can also be called ./vendor/seablast/seablast/blast.sh from a Seablast application as a management script for deployment and development.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ The framework takes care of logs, database, multiple languages, user friendly HT
 - the default environment parameters are set in the [conf/default.conf.php](conf/default.conf.php)
 - if Seablast/Auth extension is present, use its configuration
 - everything can be overriden in the web app's `conf/app.conf.php` or even in its local deployment `conf/app.conf.local.php`
-- set the default phinx environment in the phinx configuration: `['environments']['default_environment']`
-- the default `log` directory (both for SeablastMysqli/SeablastPdo query.log and Debugger::log()) can be changed as follows `->setString(SeablastConstant::SB_LOG_DIRECTORY, APP_DIR . '/log')`
+- set the default phinx environment in the phinx configuration: `['environments']['default_environment']` where the database credentials are stored. Then SeablastConfiguration provides access to MySQLi adapter through mysqli() method and PDO adapter through pdo() method.
+- the default `log` directory (both for SeablastMysqli/SeablastPdo query.log and Debugger::log()) can be changed as follows `->setString(SeablastConstant::SB_LOG_DIRECTORY, APP_DIR . '/log')`. Anyway, only levels allowed by `SeablastConstant::SB_LOGGING_LEVEL` are logged.
 
 ## Model
 
@@ -41,16 +41,12 @@ SeablastConstant::APP_MAPPING = route => [
 ]
 ```
 
-## Database adapters
-
-SeablastConfiguration provides access to MySQLi adapter through mysqli() method and PDO adapter through pdo() method.
-
 ## Authentication and authorisation
 
 - Roles are for access.
 - Routes can only be allowed for roles (never denied). I.e. access to a route can be restricted to certain roles.
 - Menu items can be both allowed and denied (e.g. don't show to an authenticated user).
-- Groups are on top of it, e.g. for promotions etc.
+- Groups are on top of it, e.g. for promotions, subscriptions etc.
 - RBAC (Role-Based Access Control): SB_IDENTITY_MANAGER provided by application MUST have methods prescribed in [IdentityManagerInterface](https://github.com/WorkOfStan/seablast-interfaces/blob/main/src/IdentityManagerInterface.php), these populate FLAG_USER_IS_AUTHENTICATED and USER_ROLE_ID.
 
 ## Security

--- a/blast.sh
+++ b/blast.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# blast.sh - Management script for deployment and development of a Seablast application
+# Usage:
+#   ./blast.sh                 # Runs assemble + creates required folders + checks web inaccessibility
+#   ./blast.sh --base-url http://localhost # Checks if defined folders are inaccessible at http://localhost
+#   ./blast.sh main            # Switches to the main branch
+#   ./blast.sh phpstan-pro     # Runs PHPStan with --pro
+#   ./blast.sh phpstan         # Runs PHPStan without --pro
+#   ./blast.sh phpstan-remove  # Removes PHPStan package
+
+# Color constants
+NC='\033[0m' # No Color
+HIGHLIGHT='\033[1;32m' # Green for sections
+WARNING='\033[0;31m' # Red for warnings
+
+# Output formatting functions
+display_header() { printf "${HIGHLIGHT}%s${NC}\n" "$1"; }
+display_warning() { printf "${WARNING}%s${NC}\n" "$1"; }
+
+# Default base URL (can be overridden by --base-url)
+BASE_URL="http://localhost"
+
+# Default paths for web inaccessibility checks
+DEFAULT_PATHS=("cache" "conf" "log" "models" "views")
+
+# Function to check web inaccessibility
+check_web_inaccessibility() {
+    local path="$1"
+    local url="${BASE_URL}${path}"
+    local status_code
+    status_code=$(curl -o /dev/null -s -w "%{http_code}" "$url")
+
+    [ "$status_code" -eq 404 ] && echo "✅ $url is correctly blocked ($status_code)." || display_warning "⚠️  Warning: $url is accessible with status $status_code."
+}
+
+# Ensures required folders exist and checks web inaccessibility
+setup_environment() {
+    local paths=("$@") # Use provided paths or default ones
+    [ ${#paths[@]} -eq 0 ] && paths=("${DEFAULT_PATHS[@]}") # If no paths given, use defaults
+
+    for folder in "${paths[@]}"; do
+        [ ! -d "$folder" ] && mkdir -p "$folder" && display_header "Created missing folder: $folder"
+        check_web_inaccessibility "/$folder/"
+    done
+
+    # Create local config if not present but the dist template is available, if newly created, then stop the script so that the admin may adapt the newly created config
+    [[ ! -f "conf/app.conf.local.php" && -f "conf/app.conf.dist.php" ]] && cp -p conf/app.conf.dist.php conf/app.conf.local.php && warning "Check/modify the newly created conf/app.conf.local.php"  && exit 0
+
+    # conf/phinx.local.php or at least conf/phinx.dist.php is required
+    if [[ ! -f "conf/phinx.local.php" ]]; then
+        [[ ! -f "conf/phinx.dist.php" ]] && warning "phinx config is required for a Seablast app" && exit 0
+        cp -p conf/phinx.dist.php conf/phinx.local.php && warning "Check/modify the newly created conf/phinx.local.php"
+        exit 0
+    fi
+}
+
+# Runs Composer update and database migrations
+assemble() {
+    display_header "-- Updating Composer dependencies --"
+    composer update -a --prefer-dist --no-progress
+
+    display_header "-- Running database migrations --"
+    vendor/bin/phinx migrate -e development --configuration ./conf/phinx.local.php
+    display_header "-- Running database TESTING migrations --"
+    # In order to properly unit test all features, set-up a test database, put its credentials to testing section of phinx.yml and run phinx migrate -e testing before phpunit
+    # Drop tables in the testing database if changes were made to migrations
+    vendor/bin/phinx migrate -e testing --configuration ./conf/phinx.local.php
+
+    [[ -f "phpunit.xml" ]] && display_header "-- Running PHPUnit --" && vendor/bin/phpunit || display_warning "NO phpunit.xml CONFIGURATION"
+}
+
+# Switches to the main branch
+back_to_main() {
+    display_header "-- Switching to main branch --"
+    git checkout --end-of-options main --
+    git pull --progress -v --no-rebase --tags --prune -- "origin"
+}
+
+# Runs PHPStan (with or without --pro)
+run_phpstan() {
+    local pro_flag="$1"
+
+    display_header "-- Installing Composer dependencies --"
+    composer install -a --prefer-dist --no-progress
+    display_header "-- Installing PHPStan (via Webmozart Assert plugin to allow for Assertions during static analysis) --"
+    composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress --with-all-dependencies
+    # TODO check if phpstan/phpstan-phpunit is needed
+    display_header "-- As PHPUnit>=7 is used the PHPUnit plugin is used for better compatibility ... --"
+    composer require --dev phpstan/phpstan-phpunit --prefer-dist --no-progress --with-all-dependencies
+
+    [[ -f "phpunit.xml" ]] && display_header "-- Running PHPUnit --" && vendor/bin/phpunit || display_warning "NO phpunit.xml CONFIGURATION"
+
+    display_header "-- Running PHPStan Analysis --"
+    vendor/bin/phpstan.phar --configuration=conf/phpstan.webmozart-assert.neon analyse . $pro_flag
+}
+
+# Removes PHPStan package
+phpstan_remove() {
+    display_header "-- Removing PHPStan package --"
+    composer remove --dev phpstan/phpstan-phpunit
+    composer remove --dev phpstan/phpstan-webmozart-assert
+}
+
+# Parse arguments
+case "$1" in
+    --base-url)
+        shift
+        BASE_URL="$1"
+        shift
+        ;;
+esac
+
+# Default behavior when no arguments are provided
+if [ $# -eq 0 ]; then
+    display_header "-- Setting up environment --"
+    setup_environment
+    display_header "-- Running assemble functionality --"
+    assemble
+    exit 0
+fi
+
+# Handle different command-line parameters
+case "$1" in
+    main) back_to_main ;;
+    phpstan) run_phpstan "--memory-limit 350M" ;;
+    phpstan-pro) run_phpstan "--memory-limit 350M --pro" ;;
+    phpstan-remove) phpstan_remove ;;
+    *)
+        display_warning "❌ Unknown option: $1"
+        echo "Usage: ./blast.sh [--base-url http://example.com][main|phpstan|phpstan-pro|phpstan-remove]"
+        exit 1
+        ;;
+esac

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Seablast for PHP - a minimalist MVC framework added by composer",
   "type": "library",
   "require": {
-    "php": "^7.2 || ^8.1",
+    "php": "^7.2 || ^8.0",
     "latte/latte": "^2.11.7 || ^3",
     "nette/utils": "^3.2.10 || ^4.0.5",
     "seablast/interfaces": "^0.1",

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,10 @@
     "latte/latte": "^2.11.7 || ^3",
     "nette/utils": "^3.2.10 || ^4.0.5",
     "seablast/interfaces": "^0.1",
-    "seablast/logger": "^2.0",
+    "seablast/logger": "^2.0.3",
     "symfony/security-csrf": "^4.4.37 || ^5 || ^6 || ^7",
-    "tracy/tracy": "^2.9.8",
-    "webmozart/assert": "^1.11.0"
+    "tracy/tracy": "^2.9.8 || ^2.10.9",
+    "webmozart/assert": "^1.10.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.4 || ^9 || ^10 || ^11 || ^12",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "webmozart/assert": "^1.11.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.4 || ^9 || ^10 || ^11",
+    "phpunit/phpunit": "^8.4 || ^9 || ^10 || ^11 || ^12",
     "robmorgan/phinx": "^0.12.13 || ^0.13.4 || ^0.14.0 || ^0.15.5 || ^0.16.5"
   },
   "suggest": {

--- a/conf/phinx.dist.php
+++ b/conf/phinx.dist.php
@@ -1,6 +1,8 @@
 <?php
 
-// only for PHPUnit tests
+declare(strict_types=1);
+
+// Unlike the applications that use it, the Seablast library uses database only for PHPUnit tests.
 return
 [
     'paths' => [

--- a/src/SeablastController.php
+++ b/src/SeablastController.php
@@ -424,8 +424,9 @@ class SeablastController
             }
             Debugger::barDump('User is authenticated');
             // Specific role expected, if not authorized => 403
-            $roleIds = explode(',', $this->mapping['roleIds']);
-            // TODO in_array comparison is loose, so even 2 equals " 2", but explode to integers would be safer
+            $roleIds = array_map('intval', explode(',', $this->mapping['roleIds']));
+            // Note: in_array comparison is loose, so 2 equals " 2", but explode to integers is safer
+            // TODO: note this to SB/dist
             Debugger::barDump($roleIds, 'RoleIds allowed');
             // Read the current user's role from the configuration object
             if (!in_array($this->configuration->getInt(SeablastConstant::USER_ROLE_ID), $roleIds)) {

--- a/src/SeablastView.php
+++ b/src/SeablastView.php
@@ -41,7 +41,7 @@ class SeablastView
             $this->renderJson($this->params->rest);
         } elseif (!isset($this->params->redirectionUrl)) {
             // HTML UI
-            if ($this->params->httpCode >= 400) {
+            if (isset($this->params->httpCode) && $this->params->httpCode >= 400) {
                 $this->model->mapping['template'] = 'error';
             }
             $this->renderLatte();


### PR DESCRIPTION
### Added

- support for PHP/8.4, including GitHub tests
- support for PHP/8.0 added again
- blast.sh - Management script for deployment and development of a Seablast application

### Changed

- mapping['roleIds'] exploded into array of integers is safer even thou in_array comparison is loose (so 2 equals " 2")