### PR TITLE
chore: backward compatibility latte/latte and seablast/logger

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
 # ignore third-party libraries, so that super-linter doesn't fail with JAVASCRIPT_ES
-assets/uls/src/jquery.uls.core.js
-assets/uls/src/jquery.uls.data.js
-assets/uls/src/jquery.uls.languagefilter.js
+assets/uls/src/jquery.uls.*.js
+assets/uls/i18n/*.json

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,0 @@
-# ignore third-party libraries, so that super-linter doesn't fail with JAVASCRIPT_ES
-assets/uls/src/jquery.uls.*.js
-assets/uls/i18n/*.json

--- a/.github/linters/zizmor.yaml
+++ b/.github/linters/zizmor.yaml
@@ -1,0 +1,7 @@
+---
+rules:
+  # disables the check - i.e. allows refering to version instead of an exact hash
+  unpinned-uses:
+    config:
+      policies:
+        "*": any

--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -67,6 +67,6 @@ jobs:
 
   super-linter:
     needs: phpcs-phpcbf
-    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@feature/super-linter-version-parametric
+    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@feature/super-linter-version-parametric
     with:
       runs-on: "ubuntu-latest"

--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.
   php-composer-unit-stan:
-    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.4
+    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@feature/super-linter-version-parametric
     with:
       # JSON
       php-version: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
@@ -67,6 +67,6 @@ jobs:
 
   super-linter:
     needs: phpcs-phpcbf
-    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.4
+    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@feature/super-linter-version-parametric
     with:
       runs-on: "ubuntu-latest"

--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -69,5 +69,7 @@ jobs:
     needs: phpcs-phpcbf
     uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@feature/super-linter-version-parametric
     with:
-      filter-regex-exclude: "^(/github/workspace/)?assets/uls/.*" # exclude 3rd party code
+      # is enough: '.*\/vendor\/.*'
+      #filter-regex-exclude: "^(/github/workspace/)?assets/uls/.*" # exclude 3rd party code
+      filter-regex-exclude: ".*\/assets\/uls\/.*" # exclude 3rd party code
       runs-on: "ubuntu-latest"

--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -69,4 +69,5 @@ jobs:
     needs: phpcs-phpcbf
     uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@feature/super-linter-version-parametric
     with:
+      filter-regex-exclude: "^(/github/workspace/)?assets/uls/.*" # exclude 3rd party code
       runs-on: "ubuntu-latest"

--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -71,5 +71,6 @@ jobs:
     with:
       # is enough: '.*\/vendor\/.*'
       #filter-regex-exclude: "^(/github/workspace/)?assets/uls/.*" # exclude 3rd party code
-      filter-regex-exclude: ".*\/assets\/uls\/.*" # exclude 3rd party code
+      #filter-regex-exclude: ".*\/assets\/uls\/.*" # exclude 3rd party code
+      filter-regex-exclude: ".*/assets/uls/.*" # exclude 3rd party code
       runs-on: "ubuntu-latest"

--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -46,9 +46,9 @@ jobs:
       - name: Invoke the Prettier fix
         uses: WorkOfStan/prettier-fix@v1.1.5
         with:
-          # TODO fix super-linter prettier vs prettier-fix
-          # commit-changes: ${{ github.event_name != 'schedule' }}
-          commit-changes: false
+          #x TODO fix super-linter prettier vs prettier-fix
+          commit-changes: ${{ github.event_name != 'schedule' }}
+          #commit-changes: false
 
   phpcs-phpcbf:
     needs: prettier-fix

--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.
   php-composer-unit-stan:
-    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@feature/super-linter-version-parametric
+    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.5
     with:
       # JSON
       php-version: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
@@ -46,9 +46,7 @@ jobs:
       - name: Invoke the Prettier fix
         uses: WorkOfStan/prettier-fix@v1.1.5
         with:
-          #x TODO fix super-linter prettier vs prettier-fix
           commit-changes: ${{ github.event_name != 'schedule' }}
-          #commit-changes: false
 
   phpcs-phpcbf:
     needs: prettier-fix
@@ -67,10 +65,7 @@ jobs:
 
   super-linter:
     needs: phpcs-phpcbf
-    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@feature/super-linter-version-parametric
+    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.5
     with:
-      # is enough: '.*\/vendor\/.*'
-      #filter-regex-exclude: "^(/github/workspace/)?assets/uls/.*" # exclude 3rd party code
-      #filter-regex-exclude: ".*\/assets\/uls\/.*" # exclude 3rd party code
-      filter-regex-exclude: ".*/assets/uls/.*" # exclude 3rd party code
+      filter-regex-exclude: ".*/assets/uls/.*" # exclude third-party code
       runs-on: "ubuntu-latest"

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,1 @@
+css/jquery.*.css # for CSS stylelint

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,2 +1,0 @@
-# CSS stylelint should ignore 3rd party code
-assets/uls/css/jquery.*.css

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,1 +1,2 @@
-css/jquery.*.css # for CSS stylelint
+# CSS stylelint should ignore 3rd party code
+assets/uls/css/jquery.*.css

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed` for any bugfixes
 
-- backward latte compatibility `"latte/latte": ">=2.10.8 <4"`
+- backward compatibility `"latte/latte": ">=2.10.8 <4"`, `"seablast/logger": "^1.0 || ^2.0.3",`
 
 ### `Security` in case of vulnerabilities
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ fix: cookies limited to app path
 ### Fixed
 
 - change .htaccess directive for Apache 2.2 `Order Allow,Deny\nDeny from all` to Apache 2.4 `Require all denied` to return 403 (instead of 500)
-- blast.sh checks for curl presence before invoking it
+- blast.sh checks for cURL presence before invoking it
 
 ### Security
 
@@ -341,7 +341,7 @@ SeablastMysqli error logging improved, HTTPS identified
 - GET parameters passed to model in configuration fields SB_GET_ARGUMENT_ID|SB_GET_ARGUMENT_CODE
 - SeablastModelInterface.php to define minimal requirements for a model used by SeablastModel
 - SeablastModel uses permanent argument Superglobals $superglobals (instead of injection `$m->setSuperglobals($superglobals);` if required by APP_MAPPING, so that it is always easily available)
-- FLAG_DEBUG_JSON: Output JSON as HTML instead of application/json so that Tracy is displayed
+- FLAG_DEBUG_JSON: Output JSON as HTML instead of `application/json` so that Tracy is displayed
 - `declare(strict_types=1);` everywhere
 - SB_WEB_FORCE_ASSET_VERSION Int to forced update of external CSS and JavaScript files
 - SB_APP_ROOT_ABSOLUTE_URL The absolute URL of the root of the application

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Removed` for now removed features
 
+- no need for .eslintignore or .stylelintignore when 3rd party code is excluded by filter-regex-exclude parameter of super-linter
+
 ### `Fixed` for any bugfixes
 
 - backward compatibility `"latte/latte": ">=2.10.8 <4"`, `"seablast/logger": "^1.0 || ^2.0.3",`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ fix: cookies limited to app path
 ### Fixed
 
 - change .htaccess directive for Apache 2.2 `Order Allow,Deny\nDeny from all` to Apache 2.4 `Require all denied` to return 403 (instead of 500)
-- blast.sh checks for cURL presence before invoking it
+- blast.sh checks for curl presence before invoking it
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added` for new features
 
 - TableViewModel for admin.latte
+- `footer.latte` populates the default latte layout `{layout '../vendor/seablast/seablast/views/BlueprintWeb.latte'}`.
 
 ### `Changed` for changes in existing functionality
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,26 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added` for new features
 
-- TableViewModel for admin.latte
-- `footer.latte` populates the default latte layout `{layout '../vendor/seablast/seablast/views/BlueprintWeb.latte'}`.
-- `namespace Seablast\Seablast\Admin;`
-- [zizmor.yaml](.github/linters/zizmor.yaml): disable unpinned-uses check - Allows referring to an action by version tag instead of exact hash, so that Dependabot can monitor and update versions automatically.
-
 ### `Changed` for changes in existing functionality
-
-- chore: super-linter bump to v8.1.0
 
 ### `Deprecated` for soon-to-be removed features
 
 ### `Removed` for now removed features
 
-- no need for .eslintignore or .stylelintignore when 3rd party code is excluded by filter-regex-exclude parameter of super-linter
-
 ### `Fixed` for any bugfixes
 
-- backward compatibility `"latte/latte": ">=2.10.8 <4"`, `"seablast/logger": "^1.0 || ^2.0.3",`
-
 ### `Security` in case of vulnerabilities
+
+## [0.2.11.1] - 2025-08-28
+
+chore: backward compatibility latte/latte and seablast/logger
+
+### Added
+
+- TableViewModel for admin.latte (still under development)
+- `footer.latte` populates the default latte layout `{layout '../vendor/seablast/seablast/views/BlueprintWeb.latte'}`.
+- `namespace Seablast\Seablast\Admin;`
+- [zizmor.yaml](.github/linters/zizmor.yaml): disable unpinned-uses check - Allows referring to an action by version tag instead of exact hash, so that Dependabot can monitor and update versions automatically.
+
+### Changed
+
+- chore: super-linter bump to v8.1.0 (seablast/actions::v0.2.5)
+
+### Removed
+
+- no need for .eslintignore or .stylelintignore when third-party code is excluded by filter-regex-exclude parameter of super-linter
+
+### Fixed
+
+- backward compatibility `"latte/latte": ">=2.10.8 <4"`, `"seablast/logger": "^1.0 || ^2.0.3",`
 
 ## [0.2.11] - 2025-08-03
 
@@ -74,7 +86,7 @@ fix: cookies limited to app path
 ### Fixed
 
 - change .htaccess directive for Apache 2.2 `Order Allow,Deny\nDeny from all` to Apache 2.4 `Require all denied` to return 403 (instead of 500)
-- blast.sh checks for curl presence before invoking it
+- blast.sh checks for cURL presence before invoking it
 
 ### Security
 
@@ -354,7 +366,8 @@ SeablastMysqli error logging improved, HTTPS identified
 - model returns knowledge()
 - a nice Under construction page
 
-[Unreleased]: https://github.com/WorkOfStan/seablast/compare/v0.2.11...HEAD?w=1
+[Unreleased]: https://github.com/WorkOfStan/seablast/compare/v0.2.11.1...HEAD?w=1
+[0.2.11.1]: https://github.com/WorkOfStan/seablast/compare/v0.2.11...v0.2.11.1?w=1
 [0.2.11]: https://github.com/WorkOfStan/seablast/compare/v0.2.10.1...v0.2.11?w=1
 [0.2.10.1]: https://github.com/WorkOfStan/seablast/compare/v0.2.10...v0.2.10.1?w=1
 [0.2.10]: https://github.com/WorkOfStan/seablast/compare/v0.2.9...v0.2.10?w=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed` for any bugfixes
 
+- backward latte compatibility `"latte/latte": ">=2.10.8 <4"`
+
 ### `Security` in case of vulnerabilities
 
 ## [0.2.11] - 2025-08-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - TableViewModel for admin.latte
 - `footer.latte` populates the default latte layout `{layout '../vendor/seablast/seablast/views/BlueprintWeb.latte'}`.
+- namespace Seablast\Seablast\Admin;
 
 ### `Changed` for changes in existing functionality
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - TableViewModel for admin.latte
 - `footer.latte` populates the default latte layout `{layout '../vendor/seablast/seablast/views/BlueprintWeb.latte'}`.
-- namespace Seablast\Seablast\Admin;
+- `namespace Seablast\Seablast\Admin;`
+- [zizmor.yaml](.github/linters/zizmor.yaml): disable unpinned-uses check - Allows referring to an action by version tag instead of exact hash, so that Dependabot can monitor and update versions automatically.
 
 ### `Changed` for changes in existing functionality
+
+- chore: super-linter bump to v8.1.0
 
 ### `Deprecated` for soon-to-be removed features
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ All JSON calls and form submits MUST contain `csrfToken` handed over to the view
 - .eslintignore and .prettierignore to ignore third-party libraries, so that super-linter doesn't fail with JAVASCRIPT_ES and so that prettier doesn't change them or super-linter fails with CSS_PRETTIER, JAVASCRIPT_PRETTIER, JSON_PRETTIER, MARKDOWN_PRETTIER
 - To make the SVG icon in `.uls-trigger` adopt the `font-color` of the surrounding element, the following style was added into `uls/images/language.svg`: `fill="currentColor"`. Also `uls/css/jquery.uls.css` was changed (changed: `.uls-trigger`, added: `.uls-trigger icon` and `.uls-trigger .icon svg`).
 - based on <https://github.com/wikimedia/jquery.uls> Revision: 077c71408284f446b626b656ce206e6ed3af705c Date: 17.07.2025 14:25:10
-
   - css\jquery.uls.css
 
     ```css

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ SeablastConstant::APP_MAPPING = route => [
 ]
 ```
 
+## View
+
+- Feel free to use the default latte layout `{layout '../vendor/seablast/seablast/views/BlueprintWeb.latte'}` which can be populated by your local `nav.latte` and `footer.latte`.
+
 ## Authentication and authorisation
 
 - Roles are for access.

--- a/blast.sh
+++ b/blast.sh
@@ -11,9 +11,9 @@
 #   ./blast.sh self-update              # Self-update the app version, i.e. checks and overrides itself with a newer version if available in the vendor directory
 
 # Color constants
-NC='\033[0m' # No Color
+NC='\033[0m'           # No Color
 HIGHLIGHT='\033[1;32m' # Green for sections
-WARNING='\033[0;31m' # Red for warnings
+WARNING='\033[0;31m'   # Red for warnings
 
 # Output formatting functions
 display_header() { printf "${HIGHLIGHT}%s${NC}\n" "$1"; }
@@ -27,162 +27,166 @@ DEFAULT_PATHS=("cache" "conf" "log" "src" "views")
 
 # Function to check web inaccessibility
 check_web_inaccessibility() {
-    local path="$1"
-    local url="${BASE_URL}${path}"
-    local status_code
-    status_code=$(curl -o /dev/null -s -w "%{http_code}" "$url")
+	local path="$1"
+	local url="${BASE_URL}${path}"
+	local status_code
+	status_code=$(curl -o /dev/null -s -w "%{http_code}" "$url")
 
-    if [ "$status_code" -eq 404 ] || [ "$status_code" -eq 403 ]; then
-        echo "✅ $url is correctly blocked ($status_code)."
-    else
-        display_warning "⚠️  Warning: $url is accessible with status $status_code."
-    fi
+	if [ "$status_code" -eq 404 ] || [ "$status_code" -eq 403 ]; then
+		echo "✅ $url is correctly blocked ($status_code)."
+	else
+		display_warning "⚠️  Warning: $url is accessible with status $status_code."
+	fi
 }
 
 # Ensures required folders exist and checks web inaccessibility
 setup_environment() {
-    local paths=("$@") # Use provided paths or default ones
-    [ ${#paths[@]} -eq 0 ] && paths=("${DEFAULT_PATHS[@]}") # If no paths given, use defaults
+	local paths=("$@")                                      # Use provided paths or default ones
+	[ ${#paths[@]} -eq 0 ] && paths=("${DEFAULT_PATHS[@]}") # If no paths given, use defaults
 
-    local has_curl=false
-    if command -v curl &> /dev/null; then
-      has_curl=true
-    else
-      display_warning "⚠️  Warning: curl is not installed, so security of folders cannot be tested."
-    fi
-    for folder in "${paths[@]}"; do
-        [ ! -d "$folder" ] && mkdir -p "$folder" && display_header "Created missing folder: $folder"
-        $has_curl && check_web_inaccessibility "/$folder/"
-    done
+	local has_curl=false
+	if command -v curl &>/dev/null; then
+		has_curl=true
+	else
+		display_warning "⚠️  Warning: curl is not installed, so security of folders cannot be tested."
+	fi
+	for folder in "${paths[@]}"; do
+		[ ! -d "$folder" ] && mkdir -p "$folder" && display_header "Created missing folder: $folder"
+		$has_curl && check_web_inaccessibility "/$folder/"
+	done
 
-    # Create local config if not present but the dist template is available, if newly created, then stop the script so that the admin may adapt the newly created config
-    [[ ! -f "conf/app.conf.local.php" && -f "conf/app.conf.dist.php" ]] && cp -p conf/app.conf.dist.php conf/app.conf.local.php && display_warning "Check/modify the newly created conf/app.conf.local.php"  && exit 0
+	# Create local config if not present but the dist template is available, if newly created, then stop the script so that the admin may adapt the newly created config
+	[[ ! -f "conf/app.conf.local.php" && -f "conf/app.conf.dist.php" ]] && cp -p conf/app.conf.dist.php conf/app.conf.local.php && display_warning "Check/modify the newly created conf/app.conf.local.php" && exit 0
 
-    # conf/phinx.local.php or at least conf/phinx.dist.php is required
-    if [[ ! -f "conf/phinx.local.php" ]]; then
-        [[ ! -f "conf/phinx.dist.php" ]] && display_warning "phinx config is required for a Seablast app" && exit 0
-        cp -p conf/phinx.dist.php conf/phinx.local.php && display_warning "Check/modify the newly created conf/phinx.local.php"
-        exit 0
-    fi
+	# conf/phinx.local.php or at least conf/phinx.dist.php is required
+	if [[ ! -f "conf/phinx.local.php" ]]; then
+		[[ ! -f "conf/phinx.dist.php" ]] && display_warning "phinx config is required for a Seablast app" && exit 0
+		cp -p conf/phinx.dist.php conf/phinx.local.php && display_warning "Check/modify the newly created conf/phinx.local.php"
+		exit 0
+	fi
 }
 
 # Runs PHPUnit tests if configuration is available
 run_phpunit() {
-    if [[ -f "phpunit.xml" ]]; then
-        display_header "-- Running PHPUnit --"
-        vendor/bin/phpunit
-    else
-        display_warning "NO phpunit.xml CONFIGURATION"
-    fi
+	if [[ -f "phpunit.xml" ]]; then
+		display_header "-- Running PHPUnit --"
+		vendor/bin/phpunit
+	else
+		display_warning "NO phpunit.xml CONFIGURATION"
+	fi
 }
 
 # Runs Composer update and database migrations
 assemble() {
-    display_header "-- Updating Composer dependencies --"
-    composer update -a --prefer-dist --no-progress
+	display_header "-- Updating Composer dependencies --"
+	composer update -a --prefer-dist --no-progress
 
-    display_header "-- Running database migrations --"
-    vendor/bin/phinx migrate -e development --configuration ./conf/phinx.local.php
-    display_header "-- Running database TESTING migrations --"
-    # In order to properly unit test all features, set-up a test database, put its credentials to testing section of phinx.yml and run phinx migrate -e testing before phpunit
-    # Drop tables in the testing database if changes were made to migrations
-    vendor/bin/phinx migrate -e testing --configuration ./conf/phinx.local.php
+	display_header "-- Running database migrations --"
+	vendor/bin/phinx migrate -e development --configuration ./conf/phinx.local.php
+	display_header "-- Running database TESTING migrations --"
+	# In order to properly unit test all features, set-up a test database, put its credentials to testing section of phinx.yml and run phinx migrate -e testing before phpunit
+	# Drop tables in the testing database if changes were made to migrations
+	vendor/bin/phinx migrate -e testing --configuration ./conf/phinx.local.php
 
-    run_phpunit
+	run_phpunit
 }
 
 # Switches to the main branch
 back_to_main() {
-    display_header "-- Switching to main branch --"
-    git checkout --end-of-options main --
-    git pull --progress -v --no-rebase --tags --prune -- "origin"
+	display_header "-- Switching to main branch --"
+	git checkout --end-of-options main --
+	git pull --progress -v --no-rebase --tags --prune -- "origin"
 }
 
 # Runs PHPStan (with or without --pro)
 run_phpstan() {
-    local pro_flag="$1"
-    # Split the string into an array on spaces
-    IFS=' ' read -r -a pro_flags <<< "$pro_flag"
+	local pro_flag="$1"
+	# Split the string into an array on spaces
+	IFS=' ' read -r -a pro_flags <<<"$pro_flag"
 
-    display_header "-- Installing Composer dependencies --"
-    composer install -a --prefer-dist --no-progress
-    display_header "-- Installing PHPStan (via Webmozart Assert plugin to allow for Assertions during static analysis) --"
-    composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress --with-all-dependencies
-    # TODO check if phpstan/phpstan-phpunit is needed
-    display_header "-- As PHPUnit>=7 is used the PHPUnit plugin is used for better compatibility ... --"
-    composer require --dev phpstan/phpstan-phpunit --prefer-dist --no-progress --with-all-dependencies
+	display_header "-- Installing Composer dependencies --"
+	composer install -a --prefer-dist --no-progress
+	display_header "-- Installing PHPStan (via Webmozart Assert plugin to allow for Assertions during static analysis) --"
+	composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress --with-all-dependencies
+	# TODO check if phpstan/phpstan-phpunit is needed
+	display_header "-- As PHPUnit>=7 is used the PHPUnit plugin is used for better compatibility ... --"
+	composer require --dev phpstan/phpstan-phpunit --prefer-dist --no-progress --with-all-dependencies
 
-    run_phpunit
+	run_phpunit
 
-    display_header "-- Running PHPStan Analysis --"
-    # $pro_flag array is expanded below
-    vendor/bin/phpstan.phar --configuration=conf/phpstan.webmozart-assert.neon analyse . "${pro_flags[@]}"
+	display_header "-- Running PHPStan Analysis --"
+	# $pro_flag array is expanded below
+	vendor/bin/phpstan.phar --configuration=conf/phpstan.webmozart-assert.neon analyse . "${pro_flags[@]}"
 }
 
 # Removes PHPStan package
 phpstan_remove() {
-    display_header "-- Removing PHPStan package --"
-    composer remove --dev phpstan/phpstan-phpunit
-    composer remove --dev phpstan/phpstan-webmozart-assert
+	display_header "-- Removing PHPStan package --"
+	composer remove --dev phpstan/phpstan-phpunit
+	composer remove --dev phpstan/phpstan-webmozart-assert
 }
 
 # Self-update function: checks for an updated version of this script and overrides itself if found
 self_update() {
-    local update_file="./vendor/seablast/seablast/blast.sh"
-    if [ -f "$update_file" ]; then
-        if [ "$update_file" -nt "$0" ]; then
-            cp "$update_file" "$0"
-            display_header "Self-update successful: Updated to the newer version from $update_file"
-        else
-            display_warning "Self-update: Update file found, but it is not newer than the current version."
-        fi
-    else
-        display_warning "Self-update: Update file not found at $update_file"
-    fi
+	local update_file="./vendor/seablast/seablast/blast.sh"
+	if [ -f "$update_file" ]; then
+		if [ "$update_file" -nt "$0" ]; then
+			cp "$update_file" "$0"
+			display_header "Self-update successful: Updated to the newer version from $update_file"
+		else
+			display_warning "Self-update: Update file found, but it is not newer than the current version."
+		fi
+	else
+		display_warning "Self-update: Update file not found at $update_file"
+	fi
 }
 
 # Parse optional base-url argument
 case "$1" in
-    --base-url)
-        shift
-        BASE_URL="$1"
-        shift
-        ;;
+--base-url)
+	shift
+	BASE_URL="$1"
+	shift
+	;;
 esac
 
 # Default behavior when no arguments are provided
 if [ $# -eq 0 ]; then
-    display_header "-- Setting up environment --"
-    setup_environment "${DEFAULT_PATHS[@]}"
-    display_header "-- Running assemble functionality --"
-    assemble
-    exit 0
+	display_header "-- Setting up environment --"
+	setup_environment "${DEFAULT_PATHS[@]}"
+	display_header "-- Running assemble functionality --"
+	assemble
+	exit 0
 fi
 
 # Handle command-line parameters
 case "$1" in
-    main)
-        printf "Switches your working tree to the specified branch: main. Git will then fetch from origin (showing you a verbose progress report), bringing in all branches and tags, deleting any remote-tracking branches that have been removed on the server, and then merge (not rebase) the corresponding remote branch into your current branch.\n"
-        read -r -n1 -p "Continue? [y/N] " reply; echo
-        [[ $reply =~ ^[Yy]$ ]] || { echo "Aborted."; exit 1; }
-        back_to_main
-        ;;
-    phpstan)
-        run_phpstan "--memory-limit 350M"
-        ;;
-    phpstan-pro)
-        run_phpstan "--memory-limit 350M --pro"
-        ;;
-    phpstan-remove)
-        phpstan_remove
-        ;;
-    self-update)
-        self_update
-        ;;
-    *)
-        display_warning "❌ Unknown option: $1"
-        echo "Usage: ./blast.sh [--base-url http://example.com][main|phpstan|phpstan-pro|phpstan-remove|self-update]"
-        echo "(See the beginning of the code for the explanation.)"
-        exit 1
-        ;;
+main)
+	printf "Switches your working tree to the specified branch: main. Git will then fetch from origin (showing you a verbose progress report), bringing in all branches and tags, deleting any remote-tracking branches that have been removed on the server, and then merge (not rebase) the corresponding remote branch into your current branch.\n"
+	read -r -n1 -p "Continue? [y/N] " reply
+	echo
+	[[ $reply =~ ^[Yy]$ ]] || {
+		echo "Aborted."
+		exit 1
+	}
+	back_to_main
+	;;
+phpstan)
+	run_phpstan "--memory-limit 350M"
+	;;
+phpstan-pro)
+	run_phpstan "--memory-limit 350M --pro"
+	;;
+phpstan-remove)
+	phpstan_remove
+	;;
+self-update)
+	self_update
+	;;
+*)
+	display_warning "❌ Unknown option: $1"
+	echo "Usage: ./blast.sh [--base-url http://example.com][main|phpstan|phpstan-pro|phpstan-remove|self-update]"
+	echo "(See the beginning of the code for the explanation.)"
+	exit 1
+	;;
 esac

--- a/blast.sh
+++ b/blast.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 # blast.sh - Management script for deployment and development of a Seablast application
-# Seablast:v0.2.10
+# Seablast:v0.2.11
 # Usage:
 #   ./blast.sh                          # Runs assemble + creates required folders + checks web inaccessibility
 #   ./blast.sh --base-url http://localhost  # Checks if defined folders are inaccessible at http://localhost
 #   ./blast.sh main                     # Switches to the main branch (after confirmation)
-#   ./blast.sh phpstan-pro              # Runs PHPStan with --pro
 #   ./blast.sh phpstan                  # Runs PHPStan without --pro
+#   ./blast.sh phpstan-pro              # Runs PHPStan with --pro
 #   ./blast.sh phpstan-remove           # Removes PHPStan package
 #   ./blast.sh self-update              # Self-update the app version, i.e. checks and overrides itself with a newer version if available in the vendor directory
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "library",
   "require": {
     "php": ">=7.2 <8.5",
-    "latte/latte": "^2.11.7 || ^3",
+    "latte/latte": ">=2.10.8 <4",
     "nette/utils": "^3.2.10 || ^4.0.5",
     "seablast/interfaces": "^0.1.1",
     "seablast/logger": "^2.0.3",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "latte/latte": ">=2.10.8 <4",
     "nette/utils": "^3.2.10 || ^4.0.5",
     "seablast/interfaces": "^0.1.1",
-    "seablast/logger": "^2.0.3",
+    "seablast/logger": "^1.0 || ^2.0.3",
     "symfony/security-csrf": "^4.4.37 || ^5 || ^6 || ^7",
     "tracy/tracy": "^2.9.8 || ^2.10.9",
     "webmozart/assert": "^1.10.0"

--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -12,8 +12,6 @@ use Tracy\Debugger;
 
 /**
  * Helper methods for AdminModel, TableViewModel and ApiTableUpdateModel
- *
- * (TODO Move to Seablast)
  */
 class AdminHelper
 {

--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WorkOfStan\Protokronika\Models;
+
+use Seablast\Seablast\Exceptions\DbmsException;
+use Seablast\Seablast\SeablastConfiguration;
+use Seablast\Seablast\SeablastConstant;
+use Seablast\Seablast\Superglobals;
+use Tracy\Debugger;
+
+/**
+ * Helper methods for AdminModel, TableViewModel and ApiTableUpdateModel
+ *
+ * (TODO Move to Seablast)
+ */
+class AdminHelper
+{
+    use \Nette\SmartObject;
+
+    /** @var array<string> */ // TODO since 8.1: public readonly
+    public $allowedTables;
+    /** @var SeablastConfiguration */
+    private $configuration;
+    /** @var Superglobals */
+    private $superglobals;
+
+    /**
+     * @param SeablastConfiguration $configuration
+     * @param Superglobals $superglobals
+     */
+    public function __construct(SeablastConfiguration $configuration, Superglobals $superglobals)
+    {
+        $this->configuration = $configuration;
+        $this->superglobals = $superglobals;
+    }
+
+    /**
+     * Populates 'App:selected-table' by the allowed selected table
+     *
+     * TODO replace 'App:selected-table' by SeablastConstant
+     *
+     * @return void
+     */
+    public function populateSelectedTable(): void
+    {
+        // Admin sees both Admin and Content tables; Content admin sees just the Content
+        $this->allowedTables = $this->getAllowedTables();
+
+        // if there's a requested table and the user has access to it, populate string 'App:selected-table'
+        if (
+            is_string($this->superglobals->get['t']) && in_array($this->superglobals->get['t'], $this->allowedTables)
+        ) {
+            $this->configuration->setString('App:selected-table', $this->superglobals->get['t']);
+        }
+    }
+
+    /**
+     * Returns list of tables that the particular user can see and/or edit.
+     *
+     * @return array<string>
+     */
+    private function getAllowedTables(): array
+    {
+        return array_merge(
+            in_array(
+                $this->configuration->getInt(SeablastConstant::USER_ROLE_ID),
+                [1, 2]
+            ) ? $this->configuration->getArrayString(
+                SeablastConstant::ADMIN_TABLE_VIEW . SeablastConstant::USER_ROLE_EDITOR
+            ) : [],
+            in_array(
+                $this->configuration->getInt(SeablastConstant::USER_ROLE_ID),
+                [1]
+            ) ? $this->configuration->getArrayString(
+                // TODO get rid of USER_ROLE_ADMIN _EDITOR etc in favor of integer id ?
+                SeablastConstant::ADMIN_TABLE_VIEW . SeablastConstant::USER_ROLE_ADMIN
+            ) : []
+        );
+    }
+
+    /**
+     * Returns array of pairs 'COLUMN_NAME' => 'DATA_TYPE'.
+     *
+     * @param string $tableName
+     * @return array<string>
+     */
+    public function columnTypes(string $tableName): array
+    {
+        // Fetch column types
+        $stmt = $this->configuration->mysqli()->prepareStrict(
+            "SELECT COLUMN_NAME, DATA_TYPE FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE()"
+            . " AND TABLE_NAME = ?"
+        );
+        $tableNameParam = $this->configuration->dbmsTablePrefix() . $tableName;
+        $stmt->bind_param('s', $tableNameParam);
+        $stmt->execute();
+
+        // Retrieve the result set as a mysqli_result object.
+        $result = $stmt->get_result();
+        if ($result === false) {
+            throw new DbmsException('Stmt get_result failed');
+        }
+
+        $columnTypes = [];
+        while ($row = $result->fetch_object()) {
+            $columnTypes[$row->COLUMN_NAME] = (string) $row->DATA_TYPE;
+        }
+        $result->free();
+        $stmt->close();
+        Debugger::barDump($columnTypes, 'columnTypes');
+        return $columnTypes;
+    }
+
+    /**
+     * Combine allowed columns for an admin according to their role.
+     *
+     * @return array<array<string>>
+     */
+    public function getAllowedColumns(): array
+    {
+        // todo if 'App:selected-table' not defined, try to get it and if not possible throw \Exception
+        $cols = [];
+        // todo refactor by recursion or smaller method
+        foreach ([SeablastConstant::ADMIN_TABLE_VIEW, SeablastConstant::ADMIN_TABLE_EDIT] as $accessRightsTypes) {
+            if (
+                in_array(
+                    $this->configuration->getInt(SeablastConstant::USER_ROLE_ID),
+                    [1, 2]
+                ) && $this->configuration->exists($accessRightsTypes . SeablastConstant::USER_ROLE_EDITOR)
+            ) {
+                $arr = $this->configuration->getArrayArrayString(
+                    $accessRightsTypes . SeablastConstant::USER_ROLE_EDITOR
+                );
+                if (array_key_exists($this->configuration->getString('App:selected-table'), $arr)) {
+                    $colsContent = [
+                        (($accessRightsTypes === SeablastConstant::ADMIN_TABLE_VIEW) ? 'view' : 'edit') =>
+                        $arr[$this->configuration->getString('App:selected-table')]
+                    ];
+                    $cols = array_merge($cols, $colsContent);
+                }
+            }
+            if (
+                in_array(
+                    $this->configuration->getInt(SeablastConstant::USER_ROLE_ID),
+                    [1]
+                ) && $this->configuration->exists($accessRightsTypes . SeablastConstant::USER_ROLE_ADMIN)
+            ) {
+                $arr = $this->configuration->getArrayArrayString(
+                    $accessRightsTypes . SeablastConstant::USER_ROLE_ADMIN
+                );
+                if (array_key_exists($this->configuration->getString('App:selected-table'), $arr)) {
+                    $colsAdmin = [
+                        (($accessRightsTypes === SeablastConstant::ADMIN_TABLE_VIEW) ? 'view' : 'edit') =>
+                        $arr[$this->configuration->getString('App:selected-table')]
+                    ];
+                    $cols = array_merge($cols, $colsAdmin);
+                }
+            }
+        }
+        return $cols;
+    }
+}

--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WorkOfStan\Protokronika\Models;
+namespace Seablast\Seablast\Admin;
 
 use Seablast\Seablast\Exceptions\DbmsException;
 use Seablast\Seablast\SeablastConfiguration;

--- a/src/Admin/AdminModel.php
+++ b/src/Admin/AdminModel.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Seablast\Seablast\Admin;
+
+use Seablast\Seablast\SeablastConfiguration;
+use Seablast\Seablast\SeablastConstant;
+use Seablast\Seablast\SeablastModelInterface;
+use Seablast\Seablast\Superglobals;
+use stdClass;
+
+/**
+ * Retrieve items from database
+ * (TODO Move to Seablast)
+ */
+class AdminModel implements SeablastModelInterface
+{
+    use \Nette\SmartObject;
+
+    /** @var AdminHelper */
+    private $adminHelper;
+    /** @var SeablastConfiguration */
+    private $configuration;
+    /** @var Superglobals */
+    private $superglobals;
+    /** @var TableViewModel|null */
+    private $tableContent = null;
+
+    /**
+     * @param SeablastConfiguration $configuration
+     * @param Superglobals $superglobals
+     */
+    public function __construct(SeablastConfiguration $configuration, Superglobals $superglobals)
+    {
+        $this->configuration = $configuration;
+        $this->superglobals = $superglobals;
+        $this->adminHelper = new AdminHelper($this->configuration, $this->superglobals);
+        $this->adminHelper->populateSelectedTable();
+        if ($this->configuration->exists('App:selected-table')) {
+            $this->tableContent = new TableViewModel($this->configuration, $this->superglobals);
+        }
+    }
+
+    /**
+     * Collection of items to be displayed.
+     *
+     * @return stdClass
+     * @throw \Exception if unimplemented HTTP method call
+     */
+    public function knowledge(): stdClass
+    {
+        if ($this->superglobals->server['REQUEST_METHOD'] === 'GET') {
+            if (is_null($this->tableContent)) {
+                $table = [];
+                $columns = [];
+                $conditionDetails = [];
+                $editable = [];
+            } else {
+                $knowledge = (array) $this->tableContent->knowledge();
+                $table =  $knowledge['table'];
+                $columns = $knowledge['columns'];
+                $editable = $knowledge['editable'];
+                $conditionDetails = $knowledge['conditionDetails'];
+            }
+
+            return (object) [
+                    'menu' => [
+                        //['label' => 'Content', 'link' => 'content'],
+                        [
+                            'label' => 'Uživatelé - stránky',
+                            'link' => $this->configuration->getString(SeablastConstant::SB_APP_ROOT_ABSOLUTE_URL) //
+                             . '/user-pages'
+                        ],
+                        [
+                            'label' => 'User management',
+                            'link' => $this->configuration->getString(SeablastConstant::SB_APP_ROOT_ABSOLUTE_URL) //
+                             . '/poseidon?t=users&condition%5B%5D=4%7C3'
+                        ],
+                        //['label' => 'Language'],
+                        [
+                            'label' => 'Logout',
+                            'link' => $this->configuration->getString(SeablastConstant::SB_APP_ROOT_ABSOLUTE_URL) //
+                            . '/user/?logout'
+                        ]
+                    ],
+                    'content' => $this->adminHelper->allowedTables,
+                    'columns' => $columns,
+                    'editable' => $editable,
+                    'conditionDetails' => $conditionDetails,
+                    'table' => $table,
+            ];
+        }
+        throw new \Exception(
+            'Wrong HTTP method request: ' . (string) print_r($this->superglobals->server['REQUEST_METHOD'], true)
+        );
+    }
+}

--- a/src/Admin/AdminModel.php
+++ b/src/Admin/AdminModel.php
@@ -12,7 +12,6 @@ use stdClass;
 
 /**
  * Retrieve items from database
- * (TODO Move to Seablast)
  */
 class AdminModel implements SeablastModelInterface
 {

--- a/src/Admin/AdminUserPagesModel.php
+++ b/src/Admin/AdminUserPagesModel.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Seablast\Seablast\Admin;
+
+use Seablast\Seablast\SeablastConfiguration;
+use Seablast\Seablast\SeablastConstant;
+use Seablast\Seablast\SeablastModelInterface;
+use Seablast\Seablast\Superglobals;
+use stdClass;
+use Tracy\Debugger;
+use Webmozart\Assert\Assert;
+
+/**
+ * Count active pages by user.
+ */
+class AdminUserPagesModel implements SeablastModelInterface
+{
+    use \Nette\SmartObject;
+
+    /** @var SeablastConfiguration */
+    private $configuration;
+    /** @var Superglobals */
+    private $superglobals;
+
+    /**
+     * @param SeablastConfiguration $configuration
+     * @param Superglobals $superglobals
+     */
+    public function __construct(SeablastConfiguration $configuration, Superglobals $superglobals)
+    {
+        $this->configuration = $configuration;
+        $this->superglobals = $superglobals;
+    }
+
+    /**
+     * Counts active items by user.
+     *
+     * It requires also the parent node to be active.
+     * But if multiple levels are involved, it still can be way off. Counting result of DataRetrievalModel would be
+     * accurate but much slower.
+     *
+     * @return stdClass
+     * @throw \Exception if unimplemented HTTP method call
+     */
+    public function knowledge(): stdClass
+    {
+        if ($this->superglobals->server['REQUEST_METHOD'] === 'GET') {
+            $stmt = $this->configuration->pdo()->queryStrict(
+                "SELECT t.owner_id,
+       u.email,
+       COUNT(*) AS item_count
+FROM `" . $this->configuration->dbmsTablePrefix() . "items` AS t
+JOIN `" . $this->configuration->dbmsTablePrefix() . "users` AS u ON t.owner_id = u.id
+LEFT JOIN `" . $this->configuration->dbmsTablePrefix() . "items` AS parent ON t.parent_id = parent.id
+WHERE t.active = 1
+  AND (
+        (t.metadata_image IS NOT NULL AND t.metadata_image <> '')
+     OR (t.metadata_text  IS NOT NULL AND t.metadata_text  <> '')
+      )
+  AND (t.parent_id IS NULL OR parent.active = 1)
+GROUP BY t.owner_id, u.email;"
+            );
+
+            // Fetch all rows as an associative array
+            $results = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+            $table = $results; // $knowledge['table'];
+            $columns = ['owner_id', 'email', 'item_count']; //$knowledge['columns'];
+            $editable = []; //$knowledge['editable'];
+            $conditionDetails = []; //$knowledge['conditionDetails'];
+
+            return (object) [
+                    'menu' => [
+                        //['label' => 'Content', 'link' => 'content'],
+                        [
+                            'label' => 'Uživatelé - stránky',
+                            'link' => $this->configuration->getString(SeablastConstant::SB_APP_ROOT_ABSOLUTE_URL) //
+                            . '/user-pages'
+                        ],
+                        [
+                            'label' => 'User management',
+                            'link' => $this->configuration->getString(SeablastConstant::SB_APP_ROOT_ABSOLUTE_URL) //
+                            . '/poseidon?t=users&condition%5B%5D=4%7C3'
+                        ],
+                        //['label' => 'Language'],
+                        [
+                            'label' => 'Logout',
+                            'link' => $this->configuration->getString(SeablastConstant::SB_APP_ROOT_ABSOLUTE_URL) //
+                            . '/user/?logout'
+                        ]
+                    ],
+                    'content' => ['test'], //$this->adminHelper->allowedTables,
+                    'columns' => $columns,
+                    'editable' => $editable,
+                    'conditionDetails' => $conditionDetails,
+                    'table' => $table,
+            ];
+        }
+        throw new \Exception(
+            'Wrong HTTP method request: ' . (string) print_r($this->superglobals->server['REQUEST_METHOD'], true)
+        );
+    }
+}

--- a/src/Admin/ApiTableUpdateModel.php
+++ b/src/Admin/ApiTableUpdateModel.php
@@ -13,7 +13,6 @@ use Tracy\Debugger;
 /**
  * Update editable fields in database
  *
- * (TODO Move to Seablast)
  * // todo DELETE via this API
  * todo use route: /api/table
  */

--- a/src/Admin/ApiTableUpdateModel.php
+++ b/src/Admin/ApiTableUpdateModel.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Seablast\Seablast\Admin;
+
+use Seablast\Seablast\Apis\GenericRestApiJsonModel;
+use Seablast\Seablast\SeablastConfiguration;
+use Seablast\Seablast\Superglobals;
+use stdClass;
+use Tracy\Debugger;
+
+/**
+ * Update editable fields in database
+ *
+ * (TODO Move to Seablast)
+ * // todo DELETE via this API
+ * todo use route: /api/table
+ */
+class ApiTableUpdateModel extends GenericRestApiJsonModel
+{
+    use \Nette\SmartObject;
+
+    /** @var AdminHelper */
+    private $adminHelper;
+
+    /**
+     * @param SeablastConfiguration $configuration
+     * @param Superglobals $superglobals
+     */
+    public function __construct(SeablastConfiguration $configuration, Superglobals $superglobals)
+    {
+        parent::__construct($configuration, $superglobals);
+
+        $this->adminHelper = new AdminHelper($this->configuration, $this->superglobals);
+        $this->adminHelper->populateSelectedTable();
+    }
+
+    /**
+     * Collection of items to be displayed.
+     *
+     * @return stdClass
+     */
+    public function knowledge(): stdClass
+    {
+        $result = parent::knowledge();
+        if ($result->httpCode >= 400) {
+            // Error state means that further processing is not desired
+            return $result;
+        }
+
+        $cols = $this->adminHelper->getAllowedColumns();
+        Debugger::barDump($cols, 'cols');
+        $columns = array_merge($cols['view'] ?? [], $cols['edit'] ?? []);
+        Debugger::barDump($columns, 'columns');
+        // Validate input
+        if (
+            empty($cols['edit'] ?? []) || !in_array($this->superglobals->get['key'], $cols['edit']) //
+            || !isset($this->superglobals->get['id']) || !is_scalar($this->superglobals->get['id']) //
+            || (int) $this->superglobals->get['id'] === 0 || !isset($this->data->val)
+        ) {
+            return self::response(403, 'Nothing to edit.');
+        }
+        $this->data->val = trim($this->data->val); // no reason to store empty lines or other whitespace around content
+        $column = $this->configuration->mysqli()->real_escape_string($this->superglobals->get['key']);
+        $columnTypes = $this->adminHelper->columnTypes($this->configuration->getString('App:selected-table'));
+        if (
+            (
+                in_array(
+                    $columnTypes[$column],
+                    ['int', 'bigint', 'smallint', 'tinyint']
+                ) && (string) (int) $this->data->val !== $this->data->val
+            ) || (
+                in_array(
+                    $columnTypes[$column],
+                    ['float', 'double', 'decimal']
+                ) && !is_numeric($this->data->val)
+            ) || !in_array(
+                $columnTypes[$column],
+                [
+                    // all accepted types
+                    'int', 'bigint', 'smallint', 'tinyint',
+                    'float', 'double', 'decimal',
+                    'char', 'varchar', 'text', 'tinytext', 'mediumtext', 'longtext',
+                    'timestamp', // comparing timestamp as pattern is not optimal //todo improve
+                ] // $this->data->val is always a string
+            )
+        ) {
+            return self::response(400, 'Input is of different type than expected.');
+        }
+
+        $id = (int) $this->superglobals->get['id']; // it's non-zero as checked above
+        // Update value
+        //UPDATE `app_items` SET `active` = '0' WHERE `app_items`.`id` = 2;
+        // todo SQL statement would be safer
+        $mysqliResult = $this->configuration->mysqli()->query(
+            'UPDATE `' . $this->configuration->dbmsTablePrefix() . $this->configuration->getString('App:selected-table')
+            . '` SET `' . $column . "` = '"
+            . $this->configuration->mysqli()->real_escape_string($this->data->val) . "' WHERE `"
+            . $this->configuration->dbmsTablePrefix() . $this->configuration->getString('App:selected-table')
+            . '`.`id` = ' . $id
+        );
+        if ($mysqliResult && $this->configuration->mysqli()->warning_count) {
+            $mysqliResult = false;
+            $warnings = $this->configuration->mysqli()->get_warnings();
+            if ($warnings !== false) {
+                do {
+                    Debugger::barDump("Warning: {$warnings->errno} {$warnings->message}", "mysqli warning");
+                } while ($warnings->next());
+            }
+        }
+        return ($mysqliResult === false) ? self::response(500, 'UPDATE failed.') : self::response(200, 'UPDATE ok.');
+    }
+}

--- a/src/Admin/TableViewModel.php
+++ b/src/Admin/TableViewModel.php
@@ -13,7 +13,6 @@ use Tracy\Debugger;
 /**
  * Retrieve items from database.
  *
- * (TODO Move to Seablast)
  * // GET:
  * // SELECT * ... explicitně uvést * v konfiguraci kvůli security; také vyjmenovat editable fields
  * // FROM ___ ... conf table

--- a/src/Admin/TableViewModel.php
+++ b/src/Admin/TableViewModel.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Seablast\Seablast\Admin;
+
+use Seablast\Seablast\SeablastConfiguration;
+use Seablast\Seablast\SeablastModelInterface;
+use Seablast\Seablast\Superglobals;
+use stdClass;
+use Tracy\Debugger;
+
+/**
+ * Retrieve items from database.
+ *
+ * (TODO Move to Seablast)
+ * // GET:
+ * // SELECT * ... explicitně uvést * v konfiguraci kvůli security; také vyjmenovat editable fields
+ * // FROM ___ ... conf table
+ * // WHERE xy ... conf filter
+ * // ORDER BY id/timestamp DESC ... defaultně id nebo conf
+ * // LIMIT offset ... zacit 1-20
+ * // todo podporovat číselníky, tedy vazby mezi tabulkama
+ * //
+ * // POST a DELETE přes API (todo CSRF) TableUpdateApi /api/table
+ * // UPDATE jen pokud editable field
+ */
+class TableViewModel implements SeablastModelInterface
+{
+    use \Nette\SmartObject;
+
+    /** @var AdminHelper */
+    private $adminHelper;
+    /** @var SeablastConfiguration */
+    private $configuration;
+    /** @var Superglobals */
+    private $superglobals;
+
+    /**
+     * @param SeablastConfiguration $configuration
+     * @param Superglobals $superglobals
+     */
+    public function __construct(SeablastConfiguration $configuration, Superglobals $superglobals)
+    {
+        $this->configuration = $configuration;
+        $this->superglobals = $superglobals;
+        $this->adminHelper = new AdminHelper($this->configuration, $this->superglobals);
+        $this->adminHelper->populateSelectedTable();
+        // TODO be able to change Limit (i.e. paging)
+        // TODO Count the possible rows
+    }
+
+    /**
+     * If there's a pipe, split the string by it.
+     *
+     * @param string $string
+     * @return ?array<string>
+     */
+    private function splitStringByFirstPipe($string): ?array
+    {
+        $position = strpos($string, '|');
+        if ($position === false) {
+            return null;
+            // If no pipe character is found, return the original string and an empty string
+            // return array($string, "");
+        }
+        return array(substr($string, 0, $position), substr($string, $position + 1));
+    }
+
+    /**
+     * Get the foreign keys information.
+     *
+     * @param string $tableName
+     * @return array<array<string, float|int|string|null>>
+     */
+    private function foreignKeys(string $tableName): array
+    {
+        //Query to List Foreign Keys in a Specific Table
+        $query = "SELECT 
+    TABLE_NAME, 
+    COLUMN_NAME, 
+    CONSTRAINT_NAME, 
+    REFERENCED_TABLE_NAME, 
+    REFERENCED_COLUMN_NAME
+FROM 
+    information_schema.KEY_COLUMN_USAGE
+WHERE 
+    TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '" . $this->configuration->dbmsTablePrefix() . $tableName . "';";
+        $result = $this->configuration->mysqli()->query($query);
+        $columnTypes = [];
+
+        if ($result && is_object($result)) {
+            while ($row = $result->fetch_assoc()) {
+                $columnTypes[] = $row;
+            }
+            $result->free();
+        }
+        return $columnTypes;
+    }
+
+    /**
+     * Collection of items to be displayed.
+     *
+     * @return stdClass
+     */
+    public function knowledge(): stdClass
+    {
+        $cols = $this->adminHelper->getAllowedColumns();
+        Debugger::barDump($cols, 'cols');
+        $columns = array_merge($cols['view'] ?? [], $cols['edit'] ?? []);
+        Debugger::barDump($columns, 'columns');
+
+        // dev
+        $foreignKeys = $this->foreignKeys($this->configuration->getString('App:selected-table'));
+        Debugger::barDump($foreignKeys, 'foreignKeys');
+
+        // Get order and conditions from GET parameters
+        $order = isset($this->superglobals->get['order']) ? $this->superglobals->get['order'] : '';
+        $conditions = [];
+        $conditionDetails = []; // todo move to AdminModel and provide here by configuration
+        $sql = '';
+        if (isset($this->superglobals->get['condition']) && is_array($this->superglobals->get['condition'])) {
+            $conditions = $this->superglobals->get['condition'];
+            $columnTypes = $this->adminHelper->columnTypes($this->configuration->getString('App:selected-table'));
+            // TODO equals operator by column type
+            // Add conditions and order clauses (this logic can be expanded as needed)
+            // Add WHERE clauses based on conditions (this is simplified for the example)
+            $whereClauses = [];
+            for ($i = 0; $i < count($conditions); $i++) {
+                if (!empty($conditions[$i])) {
+                    $condDetails = $this->splitStringByFirstPipe($conditions[$i]);
+                    if (!is_null($condDetails)) {
+                        $conditionDetails[] = $condDetails;
+                        $column = $columns[$condDetails[0]];
+                        // todo maybe SQL statement would be safer?
+                        if (
+                            in_array(
+                                $columnTypes[$column],
+                                [
+                                    'char', 'varchar', 'text', 'tinytext', 'mediumtext', 'longtext',
+                                    'timestamp', // comparing timestamp as pattern is not optimal //todo improve
+                                ]
+                            )
+                        ) {
+                            $whereClauses[] = "`{$column}` "
+                                . "LIKE"
+                                . " '" . $this->configuration->mysqli()->real_escape_string($condDetails[1]) . "'";
+                        } elseif (in_array($columnTypes[$column], ['int', 'bigint', 'smallint', 'tinyint'])) {
+                            $whereClauses[] = "`{$column}` "
+                                . "= "
+                                . (int) $condDetails[1];
+                        } elseif (in_array($columnTypes[$column], ['float', 'double', 'decimal'])) {
+                            $whereClauses[] = "`{$column}` "
+                                . '= '
+                                . (float) $condDetails[1];
+                        } else {
+                            // todo timestamp compare like number but check as string
+                            // ignore condition
+                        }
+                    }
+                    // todo the above for text fields; for int fields allow for comparing operations ><=number
+                }
+            }
+
+            if (!empty($whereClauses)) {
+                $sql .= ' WHERE ' . implode(' AND ', $whereClauses);
+            }
+        }
+        // Add ORDER BY clause
+        if (!empty($order) && is_string($order)) {
+            $orderParts = explode(',', $order);
+            $orderClauses = [];
+            foreach ($orderParts as $part) {
+                $direction = substr($part, 0, 1) == 'a' ? 'ASC' : 'DESC';
+                $columnIndex = substr($part, 1);
+                if (isset($columns[$columnIndex])) {
+                    $orderClauses[] = ' `' . $columns[$columnIndex] . "` " . $direction;
+                }
+            }
+            if (!empty($orderClauses)) {
+                $sql .= ' ORDER BY ' . implode(', ', $orderClauses);
+            }
+        }
+
+        $fields = implode('`,`', $columns);
+        $mysqliResult = $this->configuration->mysqli()->query(
+            'SELECT `' . $fields . '` '
+            . 'FROM `' . $this->configuration->dbmsTablePrefix() . $this->configuration->getString('App:selected-table')
+            . '` '
+            . $sql
+            . ' LIMIT 0,50'
+        );
+        $data = [];
+        // Fetch each row and add it to the $data array
+        if (is_object($mysqliResult)) {
+            while ($row = $mysqliResult->fetch_assoc()) {
+                $data[$row['id']] = $row;
+            }
+        }
+        return (object) [
+            // meta-data
+            'columns' => $columns,
+            'editable' => $cols['edit'] ?? [],
+            'conditionDetails' => $conditionDetails,
+            // data
+            'table' => $data,
+        ];
+    }
+}

--- a/src/README.md
+++ b/src/README.md
@@ -5,13 +5,11 @@
 2. **SeablastController**: Applies the configuration and determines the appropriate mapping based on the URL and superglobals. The mapping is retrieved from `APP_MAPPING` and assigned to `string[] mapping`. If `mapping['roleIds']` is set, the IdentityManager comes into play here.
 
 3. **SeablastModel**:
-
    - Invokes the `knowledge()` method of the app model if `controller->mapping['model']` is set.
    - Passes the results through `getParameters()` to standardize output.
    - If no model is set, it returns a CSRF token via `getParameters()`.
 
 4. **SeablastView**:
-
    - Uses data from `SeablastModel::getParameters()` to render the final output as JSON (if `rest` is present) or HTML (using a template).
 
 ```mermaid

--- a/views/BlueprintWeb.latte
+++ b/views/BlueprintWeb.latte
@@ -6,10 +6,9 @@
         {if $configuration->flag->status('I18n:SHOW_LANGUAGE_SELECTOR')}
             {include '../../../../vendor/seablast/i18n/views/uls.css.latte'}
             <script>
-                const csrfToken = {$csrfToken};{* id:sb_json *}
                 const API_BASE = {$configuration->getString('SB_APP_ROOT_ABSOLUTE_URL')};
                 const flags = ['I18n:SHOW_LANGUAGE_SELECTOR'];
-            </script>            
+            </script>
         {/if}
         <style>
             body {

--- a/views/BlueprintWeb.latte
+++ b/views/BlueprintWeb.latte
@@ -63,7 +63,7 @@
             }
         </style>
         <script>
-            const csrf_token = {$csrfToken};
+            const csrf_token = {$csrfToken};{* id:sb_json *}
         </script>
     </head>
     <body>
@@ -74,15 +74,11 @@
         </header>
 
         <main>
-            Initial content
             {block mainblock}{/block}
-            <p>CSRF token: {$csrfToken}{* id:sb_json *}</p>
         </main>
 
         <footer>
-            <p>Contact us: contact@example.com</p>
-            <p>Follow us on social media</p>
-            <!-- Social media links -->
+            {include 'inherite.latte', latte => 'footer.latte'}
         </footer>
         {if $configuration->flag->status('I18n:SHOW_LANGUAGE_SELECTOR')}
             <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>

--- a/views/footer.latte
+++ b/views/footer.latte
@@ -1,0 +1,3 @@
+            <p>Contact us: contact@example.com</p>
+            <p>Follow us on social media</p>
+            <!-- Social media links -->


### PR DESCRIPTION
### Added

- TableViewModel for admin.latte (still under development)
- `footer.latte` populates the default latte layout `{layout '../vendor/seablast/seablast/views/BlueprintWeb.latte'}`.
- `namespace Seablast\Seablast\Admin;`
- [zizmor.yaml](.github/linters/zizmor.yaml): disable unpinned-uses check - Allows referring to an action by version tag instead of exact hash, so that Dependabot can monitor and update versions automatically.

### Changed

- chore: super-linter bump to v8.1.0 (seablast/actions::v0.2.5)

### Removed

- no need for .eslintignore or .stylelintignore when third-party code is excluded by filter-regex-exclude parameter of super-linter

### Fixed

- backward compatibility `"latte/latte": ">=2.10.8 <4"`, `"seablast/logger": "^1.0 || ^2.0.3",`
