### PR TITLE
fix: suppress PHP/8.4 deprecation for PDO::query, exclude Latte 3.1

### DIFF
--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -54,7 +54,7 @@ jobs:
 
   # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.
   php-composer-unit-stan:
-    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.8
+    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.9
     with:
       # JSON
       php-version: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]'
@@ -95,7 +95,7 @@ jobs:
 
   super-linter:
     needs: phpcs-phpcbf
-    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.8
+    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.9
     with:
       # exclude third-party code
       filter-regex-exclude: ".*/assets/uls/.*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Security` in case of vulnerabilities
 
+## [0.2.17.3] - 2026-03-29
+
+fix: fix XSS in `Overlay`
+
+### Added
+
+- add `./blast.sh clean` command to preview and remove temporary cache and audio marker files after explicit `YES` confirmation
+
+### Changed
+
+- harden `blast.sh` with `set -euo pipefail`, safe `--base-url` parsing and non-fatal curl reachability warnings
+
+### Fixed
+
+- suppress PHP/8.4 deprecation for `SeablastPdo::query()` by adding `#[\ReturnTypeWillChange]` while preserving PHP/7.2 compatibility
+- avoid `Undefined array key "t"` warning in `AdminHelper::populateSelectedTable()` when no table is selected in the query string
+
+### Security
+
 - fix XSS in `Overlay`: text editor now HTML-escapes user input before inserting it into `.html(...)` on success (while preserving new lines as `<br>`), so injected tags/scripts are rendered as text and are not executed in the browser.
 
 ## [0.2.17.2] - 2026-03-15
@@ -487,7 +506,8 @@ SeablastMysqli error logging improved, HTTPS identified
 - **model returns knowledge()**
 - a nice Under construction page
 
-[Unreleased]: https://github.com/WorkOfStan/seablast/compare/v0.2.17.2...HEAD?w=1
+[Unreleased]: https://github.com/WorkOfStan/seablast/compare/v0.2.17.3...HEAD?w=1
+[0.2.17.3]: https://github.com/WorkOfStan/seablast/compare/v0.2.17.2...v0.2.17.3?w=1
 [0.2.17.2]: https://github.com/WorkOfStan/seablast/compare/v0.2.17.1...v0.2.17.2?w=1
 [0.2.17.1]: https://github.com/WorkOfStan/seablast/compare/v0.2.17...v0.2.17.1?w=1
 [0.2.17]: https://github.com/WorkOfStan/seablast/compare/v0.2.16...v0.2.17?w=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,12 @@ fix: fix XSS in `Overlay`
 ### Added
 
 - add `./blast.sh clean` command to preview and remove temporary cache and audio marker files after explicit `YES` confirmation
+- add `CLAUDE.md` as a maintainer and application-integration guide that documents Seablast bootstrap, routing, model/view contracts, admin behavior, and current implementation caveats
 
 ### Changed
 
-- harden `blast.sh` with `set -euo pipefail`, safe `--base-url` parsing and non-fatal curl reachability warnings
+- harden `blast.sh` with `set -euo pipefail`, safe `--base-url` parsing and non-fatal cURL reachability warnings
+- limit Latte `>=2.10.8 <3.1` as the implementation of filters differs between Latte 3.0 and 3.1
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,355 @@
+# CLAUDE.md
+
+This file is the maintainer and integration guide for `seablast/seablast`.
+It is written for two audiences:
+
+- maintainers changing the framework itself
+- applications that build on top of Seablast and need to understand its real runtime contract
+
+This document describes the current behavior of the codebase, including important caveats that are not obvious from the marketing-level README alone.
+
+## What Seablast Is
+
+Seablast is a composer-installed minimalist MVC runtime for PHP applications.
+The core runtime is small and centered around four classes:
+
+1. `SeablastSetup`
+2. `SeablastController`
+3. `SeablastModel`
+4. `SeablastView`
+
+Applications extend the framework mostly by:
+
+- providing configuration closures in `conf/app.conf.php` and `conf/app.conf.local.php`
+- registering routes in `SeablastConstant::APP_MAPPING`
+- implementing models that return `stdClass`
+- overriding or inheriting Latte templates
+
+Optional integrations include:
+
+- `seablast/auth`
+- `seablast/i18n`
+
+## Bootstrap and Request Lifecycle
+
+The runtime flow is:
+
+1. `defineAppDir.php` defines `APP_DIR`.
+   If the library is executed from `vendor/seablast/seablast`, `APP_DIR` resolves to the application root.
+2. `index.php` loads `APP_DIR . '/vendor/autoload.php'`, enables Tracy, and creates `SeablastSetup`.
+3. `SeablastSetup` builds a single `SeablastConfiguration` instance by loading configuration closures in precedence order.
+4. `SeablastController` applies environment configuration, derives runtime values, starts the session, resolves the route, and enforces authentication/authorization.
+5. `SeablastModel` instantiates the mapped application model, calls `knowledge()`, and always injects a CSRF token into the returned parameters.
+6. `SeablastView` renders JSON, HTML, or redirect output and then exposes Tracy SQL and HTTP panels.
+
+When maintaining the framework, preserve this order. Session setup, Tracy wiring, runtime-derived configuration, and route resolution are coupled.
+
+## Configuration Layering
+
+`SeablastSetup` currently loads configuration files in this order, from lowest to highest priority:
+
+1. `conf/default.conf.php`
+2. `APP_DIR/vendor/seablast/auth/conf/app.conf.php`
+3. `APP_DIR/vendor/seablast/i18n/conf/app.conf.php`
+4. `APP_DIR/conf/app.conf.php`
+5. `APP_DIR/conf/app.conf.local.php`
+
+Each file must return a callable that accepts `SeablastConfiguration`.
+
+This means application config can override:
+
+- framework defaults
+- auth defaults
+- i18n defaults
+- environment-local overrides
+
+If you change this order, you are changing a public integration contract.
+
+## Runtime Values Added by Core
+
+The controller populates several values at runtime that applications may read later:
+
+- `SeablastConstant::SB_APP_ROOT_ABSOLUTE_URL`
+- `SeablastConstant::SB_GET_ARGUMENT_ID`
+- `SeablastConstant::SB_GET_ARGUMENT_CODE`
+- `SeablastConstant::ERROR_HTTP_CODE`
+- `SeablastConstant::ERROR_MESSAGE`
+- `SeablastConstant::USER_ID`
+- `SeablastConstant::USER_ROLE_ID`
+- `SeablastConstant::USER_GROUPS`
+- `SeablastConstant::FLAG_USER_IS_AUTHENTICATED`
+
+Applications should treat these as framework-owned runtime state, not as values to preseed manually.
+
+## Route Contract
+
+Routes live in `SeablastConstant::APP_MAPPING` and are matched by exact path after:
+
+- removing the application base path from `REQUEST_URI`
+- trimming a trailing slash
+- defaulting an empty path to `/`
+
+The framework currently consumes these mapping keys:
+
+- `model`: fully qualified class name of the model
+- `template`: Latte template name without `.latte`
+- `roleIds`: comma-separated allow-list of numeric role IDs
+- `id`: required GET parameter name, stored as `SB_GET_ARGUMENT_ID`
+- `code`: required GET parameter name, validated and stored as `SB_GET_ARGUMENT_CODE`
+
+Notes:
+
+- Missing routes are converted to `/error`, not to a generic JSON error route.
+- A route with `roleIds` requires a configured identity manager.
+- `code` is intentionally restricted and rejects control characters, quotes, backslashes, semicolons, and SQL comment markers.
+
+If you add new mapping keys in core, document them in `README.md`, this file, and tests.
+
+## Model Contract for Applications
+
+Application models are expected to implement the same contract as `SeablastModelInterface`:
+
+- constructor signature: `__construct(SeablastConfiguration $configuration, Superglobals $superglobals)`
+- method: `knowledge(): stdClass`
+
+`SeablastModel` instantiates the mapped class directly and then calls `knowledge()`.
+
+Special properties in the returned `stdClass`:
+
+- `rest`: when present, Seablast renders JSON instead of HTML
+- `httpCode`: optional HTTP status code
+- `redirectionUrl`: when present, Seablast sends a redirect and renders `redirection.latte`
+- `title`: used by `BlueprintWeb.latte` as page title
+
+The framework also always adds:
+
+- `csrfToken`
+
+Important consequences:
+
+- A model must return `stdClass`, not an array.
+- JSON responses can return `rest` as either an object or an array.
+- Redirect codes are limited to `301`, `302`, `303`, `307`, and `308`.
+- For non-REST HTML responses with `httpCode >= 400`, `SeablastView` forces the `error` template.
+
+## Generic JSON API Contract
+
+`GenericRestApiJsonModel` is the base implementation for JSON endpoints.
+
+Current behavior:
+
+- requires `REQUEST_METHOD` in `Superglobals->server`
+- reads JSON from `php://input`, or from `SeablastConstant::JSON_INPUT` when injected for tests
+- accepts only a decoded JSON object
+- requires `csrfToken`
+- validates the token against the `sb_json` token ID
+
+Default error behavior:
+
+- `400` for invalid JSON or wrong payload shape
+- `401` for missing or invalid CSRF token
+
+Applications extending this class should call `parent::knowledge()` first and stop when it already returns `httpCode >= 400`.
+
+## View and Template Contract
+
+`SeablastView` injects one more template variable before rendering:
+
+- `configuration`
+
+Bundled template lookup behavior:
+
+- first try `../../../<LATTE_TEMPLATE>/<template>.latte`
+- otherwise use `<LATTE_TEMPLATE>/<template>.latte` from the bundled library
+
+In the standard vendor layout, the first path resolves to the application template directory. If you change bootstrap location or current working directory assumptions, re-check template inheritance carefully.
+
+With the default `LATTE_TEMPLATE = 'views'`, applications override bundled templates by placing files in:
+
+- `APP_DIR/views/*.latte`
+
+### BlueprintWeb Expectations
+
+The bundled `views/BlueprintWeb.latte` assumes these are available:
+
+- `$csrfToken`
+- `$configuration`
+- `SeablastConstant::SB_APP_ROOT_ABSOLUTE_URL`
+- `SeablastConstant::SB_WEB_FORCE_ASSET_VERSION`
+
+Important: `SB_WEB_FORCE_ASSET_VERSION` is not set by `conf/default.conf.php`, but the bundled layout reads it unconditionally. Applications that use `BlueprintWeb.latte` should define it explicitly.
+
+The layout also:
+
+- loads jQuery
+- loads `assets/scripts/seablast-bridge.js`
+- optionally includes Seablast I18n ULS assets when the i18n flag is active
+
+## Authentication and Authorization
+
+If `SeablastConstant::SB_IDENTITY_MANAGER` is configured, the controller instantiates the class with:
+
+- `new $identityManager($configuration->mysqli())`
+
+The class is expected to match `seablast/interfaces` behavior.
+
+The controller also supports optional integration methods when they exist:
+
+- `setTablePrefix()`
+- `setCookiePath()`
+
+If the identity says the user is authenticated, core writes user data into configuration and injects the user ID into DB adapters for query logging.
+
+Route protection behavior:
+
+- no authentication and protected route: use `APP_MAPPING_401` when configured, otherwise render a `401` error page
+- authenticated but wrong role: render a `403` error page
+
+## Database Contract
+
+Database credentials are read from:
+
+- `APP_DIR/conf/phinx.local.php`
+
+The effective environment is:
+
+- `SeablastConstant::SB_PHINX_ENVIRONMENT` when set
+- otherwise `environments.default_environment` from the Phinx config
+
+`SeablastConfiguration` exposes two lazy adapters:
+
+- `mysqli()`
+- `pdo()`
+
+Useful behavior to preserve:
+
+- both adapters log write-like queries
+- both adapters collect statements for Tracy bar panels
+- `setUser()` propagates the current user to both adapters
+- `dbmsTablePrefix()` lazily initializes a preferred connection when needed
+
+Deprecated compatibility methods still present:
+
+- `dbms()`
+- `dbmsStatus()`
+
+Maintain backward compatibility unless you intentionally ship a breaking change.
+
+## Admin Contract
+
+Bundled default routes:
+
+- `/poseidon`
+- `/api/poseidon`
+
+Admin permissions are split into:
+
+- table visibility: `ADMIN_TABLE_VIEW`
+- editable columns: `ADMIN_TABLE_EDIT`
+- insert permission: `ADMIN_TABLE_INSERT_ROW`
+- delete permission: `ADMIN_TABLE_DELETE_ROW`
+
+Applications configure them by appending the role suffix constant, for example:
+
+- `SeablastConstant::ADMIN_TABLE_VIEW . SeablastConstant::USER_ROLE_EDITOR`
+
+### Current Admin Behavior
+
+The bundled admin currently supports:
+
+- table listing
+- column-level view/edit permissions
+- filtering
+- ordering
+- inline cell updates through `/api/poseidon`
+
+Filtering and ordering details:
+
+- selected table comes from GET parameter `t`
+- filters are passed as repeated `condition[]` values in the format `columnIndex|value`
+- ordering is passed as `order=a0,d2`
+- result limit is hardcoded to `50`
+
+Inline update details:
+
+- GET parameters: `t`, `key`, `id`
+- JSON body must contain `csrfToken` and `val`
+
+### Important Admin Caveats
+
+These are part of the current reality and should be documented for app integrators:
+
+- `AdminHelper` hardcodes role inheritance for role `1` as admin and role `2` as editor. The role constants exist in config, but the current helper logic still assumes those numeric values.
+- Insert/delete permission flags are exposed, but the bundled admin UI/API is still focused on view/edit and does not yet implement a full insert/delete workflow.
+- The bundled admin menu contains opinionated links such as `/user-pages` and `/user/?logout`; applications may need to override the admin template or model if those routes do not exist.
+- Some bundled admin and error UI strings are still Czech.
+
+## Under Construction Mode
+
+If `FLAG_WEB_RUNNING` is not active, the controller serves `under-construction.html` and exits.
+
+Bypass rules:
+
+- localhost (`::1`, `127.0.0.1`)
+- IPs listed in `DEBUG_IP_LIST`
+
+The application may override the static file by placing:
+
+- `APP_DIR/under-construction.html`
+
+## Debugging and Logging
+
+Tracy is enabled in development mode for:
+
+- localhost
+- IPs listed in `DEBUG_IP_LIST`
+
+`FLAG_DEBUG_JSON` intentionally suppresses the JSON `Content-Type` header so Tracy can render debug output more comfortably. This is a local debugging aid and should not be enabled in normal production traffic.
+
+SQL bar panels are rendered after output selection so that database diagnostics survive normal page, JSON, and redirect flows.
+
+## Current Realities and Non-Goals
+
+These points are worth keeping in mind when maintaining or integrating Seablast:
+
+- The controller currently performs direct path matching. Friendly URL database resolution and redirector logic are still marked as TODO in code.
+- Route misses currently fall back to `/error`, which means missing API routes are not automatically rendered as JSON.
+- The bundled templates are functional defaults, not a complete design system.
+- `README.md` contains the broad usage story, but this file should remain the source of truth for framework internals and hidden contracts.
+
+## Change Checklist for Maintainers
+
+When changing core behavior, verify all affected layers together:
+
+- bootstrap: `defineAppDir.php`, `index.php`, session timing, Tracy setup
+- configuration: new constants, defaults, override order, runtime-populated values
+- routing: `APP_MAPPING`, auth flow, error flow, GET parameter extraction
+- model/view contract: `stdClass`, `csrfToken`, `rest`, `httpCode`, redirects
+- templates/assets: override rules, required config keys, asset versioning
+- database: lazy init, table prefix, query logging, Tracy panels
+- admin: role inheritance, table permissions, filtering, inline edit behavior
+- docs/tests: `README.md`, `CHANGELOG.md`, this file, PHPUnit expectations
+
+## Testing and Local Development
+
+Useful local commands:
+
+- PHPUnit: run the repository test suite with your usual PHP/PHPUnit entry point
+- PHPStan on Windows: `& "C:\Program Files\Git\bin\bash.exe" -lc "./blast.sh phpstan"`
+
+Important test assumptions:
+
+- tests expect `conf/phinx.local.php`
+- tests commonly switch `SB_PHINX_ENVIRONMENT` to `testing`
+- some bundled templates assume app-level config such as `SB_WEB_FORCE_ASSET_VERSION`
+
+## Documentation Policy
+
+If a change affects framework behavior that applications depend on, update all of these together:
+
+- `README.md` for public usage guidance
+- `CHANGELOG.md` for release notes
+- `CLAUDE.md` for maintainer and integration detail
+- tests where the behavior is asserted
+
+That keeps Seablast honest for both maintainers and downstream applications.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ It is written for two audiences:
 - maintainers changing the framework itself
 - applications that build on top of Seablast and need to understand its real runtime contract
 
-This document describes the current behavior of the codebase, including important caveats that are not obvious from the marketing-level README alone.
+This document describes the current behavior of the codebase, including important caveats that are not obvious from the marketing-level `README.md` alone.
 
 ## What Seablast Is
 
@@ -312,7 +312,7 @@ SQL bar panels are rendered after output selection so that database diagnostics 
 
 These points are worth keeping in mind when maintaining or integrating Seablast:
 
-- The controller currently performs direct path matching. Friendly URL database resolution and redirector logic are still marked as TODO in code.
+- The controller currently performs direct path matching. Friendly URL database resolution and redirector logic are still marked as `TODO` in code.
 - Route misses currently fall back to `/error`, which means missing API routes are not automatically rendered as JSON.
 - The bundled templates are functional defaults, not a complete design system.
 - `README.md` contains the broad usage story, but this file should remain the source of truth for framework internals and hidden contracts.

--- a/blast.sh
+++ b/blast.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
 # blast.sh - Management script for deployment and development of a Seablast application
-# Seablast:v0.2.14
+# Seablast:v0.2.17.3
+# Fail fast on real script errors:
+# -e: stop on unexpected non-zero exit codes
+# -u: treat unset variables as errors, which makes argument handling stricter
+# -o pipefail: fail a pipeline when any command in it fails
+set -euo pipefail
+
 # Usage:
 #   ./blast.sh                          # Runs assemble + creates required folders + checks web inaccessibility
-#   ./blast.sh --base-url http://localhost  # Checks if defined folders are inaccessible at http://localhost
+#   ./blast.sh --base-url http://localhost  # Runs the default action with a custom base URL for folder checks
+#   ./blast.sh clean                    # Previews and deletes temporary cache/audio marker files after confirmation
 #   ./blast.sh main                     # Switches to the main branch (after confirmation)
 #   ./blast.sh phpstan                  # Runs PHPStan without --pro
 #   ./blast.sh phpstan-pro              # Runs PHPStan with --pro
@@ -19,6 +26,12 @@ WARNING='\033[0;31m'   # Red for warnings
 display_header() { printf "${HIGHLIGHT}%s${NC}\n" "$1"; }
 display_warning() { printf "${WARNING}%s${NC}\n" "$1"; }
 
+# Shared usage output so CLI validation errors stay consistent.
+print_usage() {
+	echo "Usage: ./blast.sh [--base-url http://example.com] [clean|main|phpstan|phpstan-pro|phpstan-remove|self-update]"
+	echo "(See the beginning of the code for the explanation.)"
+}
+
 # Default base URL (can be overridden by --base-url)
 BASE_URL="http://localhost"
 
@@ -30,12 +43,17 @@ check_web_inaccessibility() {
 	local path="$1"
 	local url="${BASE_URL}${path}"
 	local status_code
-	status_code=$(curl -o /dev/null -s -w "%{http_code}" "$url")
 
-	if [ "$status_code" -eq 404 ] || [ "$status_code" -eq 403 ]; then
-		echo "✅ $url is correctly blocked ($status_code)."
+	# With `set -e`, run curl inside `if` so connection problems only warn and do not
+	# abort the whole setup when a local web server is temporarily unavailable.
+	if status_code=$(curl -o /dev/null -s -w "%{http_code}" "$url" 2>/dev/null); then
+		if [ "$status_code" -eq 404 ] || [ "$status_code" -eq 403 ]; then
+			echo "[OK] $url is correctly blocked ($status_code)."
+		else
+			display_warning "Warning: $url is accessible with status $status_code."
+		fi
 	else
-		display_warning "⚠️  Warning: $url is accessible with status $status_code."
+		display_warning "Warning: $url could not be checked because curl could not reach it."
 	fi
 }
 
@@ -48,14 +66,15 @@ setup_environment() {
 	if command -v curl &>/dev/null; then
 		has_curl=true
 	else
-		display_warning "⚠️  Warning: curl is not installed, so security of folders cannot be tested."
+		display_warning "Warning: curl is not installed, so security of folders cannot be tested."
 	fi
 	for folder in "${paths[@]}"; do
 		[ ! -d "$folder" ] && mkdir -p "$folder" && display_header "Created missing folder: $folder"
 		$has_curl && check_web_inaccessibility "/$folder/"
 	done
 
-	# Create local config if not present but the dist template is available, if newly created, then stop the script so that the admin may adapt the newly created config
+	# Create local config if not present but the dist template is available. If newly
+	# created, then stop the script so that the admin may adapt the new config first.
 	[[ ! -f "conf/app.conf.local.php" && -f "conf/app.conf.dist.php" ]] && cp -p conf/app.conf.dist.php conf/app.conf.local.php && display_warning "Check/modify the newly created conf/app.conf.local.php" && exit 0
 
 	# conf/phinx.local.php or at least conf/phinx.dist.php is required
@@ -84,11 +103,38 @@ assemble() {
 	display_header "-- Running database migrations --"
 	vendor/bin/phinx migrate -e development --configuration ./conf/phinx.local.php
 	display_header "-- Running database TESTING migrations --"
-	# In order to properly unit test all features, set-up a test database, put its credentials to testing section of the phinx configuration file and run phinx migrate -e testing before phpunit
-	# Drop tables in the testing database if changes were made to migrations
+	# In order to properly unit test all features, set-up a test database, put its
+	# credentials to the testing section of the phinx configuration file and run
+	# phinx migrate -e testing before phpunit.
+	# Drop tables in the testing database if changes were made to migrations.
 	vendor/bin/phinx migrate -e testing --configuration ./conf/phinx.local.php
 
 	run_phpunit
+}
+
+# Previews and removes temporary files created during development
+clean_temp_files() {
+	display_header "-- Files to be deleted (preview) --"
+	# ls returns non-zero when no glob matches, which is acceptable for this preview.
+	# We do not want the script to stop in that case, so we append "|| true".
+	ls -1 cache/*.php cache/*.lock uploads/audios/*.del 2>/dev/null || true
+	echo
+
+	read -r -p "Do you really want to delete the files listed above? Type YES to continue: " confirm
+	if [[ "${confirm}" != "YES" ]]; then
+		echo "Aborted."
+		exit 0
+	fi
+
+	display_header "-- Deleting temporary files --"
+	# -v: verbose, prints the name of each removed file
+	# -f: force, ignore nonexistent files and do not prompt
+	# Keep "2>/dev/null || true" so unmatched globs do not abort the script under
+	# `set -e` in environments with slightly different shell behaviour.
+	rm -fv cache/*.php cache/*.lock 2>/dev/null || true
+	rm -fv uploads/audios/*.del 2>/dev/null || true
+
+	echo "Done."
 }
 
 # Switches to the main branch
@@ -125,7 +171,7 @@ run_phpstan() {
 # Removes PHPStan package
 phpstan_remove() {
 	display_header "-- Removing PHPStan package --"
-	# It doesn't matter if phpstan/phpstan-phpunit was not required before
+	# It does not matter if phpstan/phpstan-phpunit was not required before.
 	composer remove --dev phpstan/phpstan-phpunit
 	composer remove --dev phpstan/phpstan-webmozart-assert
 }
@@ -145,14 +191,18 @@ self_update() {
 	fi
 }
 
-# Parse optional base-url argument
-case "$1" in
---base-url)
-	shift
-	BASE_URL="$1"
-	shift
-	;;
-esac
+# Parse optional base-url argument.
+# Under `set -u`, use `${1-}` / `${2-}` so a missing CLI value can be handled
+# with a friendly error instead of an immediate "unbound variable" exit.
+if [[ "${1-}" == "--base-url" ]]; then
+	if [[ -z "${2-}" ]]; then
+		display_warning "Missing value for --base-url."
+		print_usage
+		exit 1
+	fi
+	BASE_URL="$2"
+	shift 2
+fi
 
 # Default behavior when no arguments are provided
 if [ $# -eq 0 ]; then
@@ -164,7 +214,10 @@ if [ $# -eq 0 ]; then
 fi
 
 # Handle command-line parameters
-case "$1" in
+case "${1-}" in
+clean)
+	clean_temp_files
+	;;
 main)
 	printf "Switches your working tree to the specified branch: main. Git will then fetch from origin (showing you a verbose progress report), bringing in all branches and tags, deleting any remote-tracking branches that have been removed on the server, and then merge (not rebase) the corresponding remote branch into your current branch.\n"
 	read -r -n1 -p "Continue? [y/N] " reply
@@ -188,9 +241,8 @@ self-update)
 	self_update
 	;;
 *)
-	display_warning "❌ Unknown option: $1"
-	echo "Usage: ./blast.sh [--base-url http://example.com][main|phpstan|phpstan-pro|phpstan-remove|self-update]"
-	echo "(See the beginning of the code for the explanation.)"
+	display_warning "Unknown option: ${1-}"
+	print_usage
 	exit 1
 	;;
 esac

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "robmorgan/phinx": "^0.12.13 || ^0.13.4 || ^0.14.0 || ^0.15.5 || ^0.16.5"
   },
   "suggest": {
-    "seablast/auth": "No-password authentication and authorisation extension for Seablast for PHP"
+    "seablast/auth": "No-password authentication and authorisation extension for Seablast for PHP",
+    "seablast/i18n": "A lightweight internationalization (i18n) module to effortlessly provide multilingual support and manage user language preferences"
   },
   "license": "MIT",
   "authors": [

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "webmozart/assert": "^1.10.0 || ^2.1.5"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.5.52 || ^9 || ^10 || ^11 || ^12",
+    "phpunit/phpunit": "^8.5.52 || ^9 || ^10 || ^11 || ^12 || ^13",
     "robmorgan/phinx": "^0.12.13 || ^0.13.4 || ^0.14.0 || ^0.15.5 || ^0.16.5"
   },
   "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "library",
   "require": {
     "php": ">=7.2 <8.6",
-    "latte/latte": ">=2.10.8 <4",
+    "latte/latte": ">=2.10.8 <3.1",
     "nette/utils": "^3.2.10 || ^4.0.5 || ^4.1.0",
     "seablast/interfaces": "^0.1.1",
     "seablast/logger": "^1.0 || ^2.0.3",

--- a/conf/phpstan.app.neon
+++ b/conf/phpstan.app.neon
@@ -9,5 +9,5 @@ parameters:
       - ../defineAppDir.php
     scanDirectories:
       - ../src
-    # as PHPStan 2.0 reports other things than 1.x (and 1.x is still needed to support PHP/7.2 and 7.3
+    # as PHPStan 2.0 reports other things than 1.x (and 1.x is still needed to support PHP/7.2 and 7.3)
     reportUnmatchedIgnoredErrors: false

--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -44,13 +44,12 @@ class AdminHelper
     {
         // Admin sees both Admin and Content tables; Content admin sees just the Content
         $this->allowedTables = $this->getAllowedTables(SeablastConstant::ADMIN_TABLE_VIEW);
+        $selectedTable = $this->superglobals->get['t'] ?? null;
 
         // if there's a requested table and the user has access to it,
         // populate string SeablastConstant::APP_SELECTED_TABLE
-        if (
-            is_string($this->superglobals->get['t']) && in_array($this->superglobals->get['t'], $this->allowedTables)
-        ) {
-            $this->configuration->setString(SeablastConstant::APP_SELECTED_TABLE, $this->superglobals->get['t']);
+        if (is_string($selectedTable) && in_array($selectedTable, $this->allowedTables, true)) {
+            $this->configuration->setString(SeablastConstant::APP_SELECTED_TABLE, $selectedTable);
         }
     }
 

--- a/src/SeablastPdo.php
+++ b/src/SeablastPdo.php
@@ -162,6 +162,7 @@ class SeablastPdo extends PDO
      * @return PDOStatement|false
      * @throws DbmsException
      */
+    #[\ReturnTypeWillChange]
     public function query(string $query, ?int $fetchMode = null, ...$fetchModeArgs)
     {
         $trimmedQuery = trim($query);

--- a/src/SeablastView.php
+++ b/src/SeablastView.php
@@ -148,7 +148,8 @@ class SeablastView
             Debugger::barDump($translatorClass, 'Translate class');
             $translator = new $translatorClass($this->model->getConfiguration());
 
-            // for Latte 2 and 3
+            // Todo make thorough testing for upgrade to Latte 3.1
+            // for Latte 2 and 3.0
             if (method_exists($translator, 'translate')) {
                 //Debugger::barDump('Translator exists');
                 Debugger::barDump($latte, 'before filter');
@@ -156,7 +157,7 @@ class SeablastView
                     return $translator->translate($s);
                 });
                 //Debugger::barDump($latte, 'after filter');
-            }
+            }            
             /*} else {
                 // for Latte 3, i.e. PHP/8.0-8.4
                 //$translator = new MyTranslator($lang);

--- a/src/SeablastView.php
+++ b/src/SeablastView.php
@@ -157,7 +157,7 @@ class SeablastView
                     return $translator->translate($s);
                 });
                 //Debugger::barDump($latte, 'after filter');
-            }            
+            }
             /*} else {
                 // for Latte 3, i.e. PHP/8.0-8.4
                 //$translator = new MyTranslator($lang);


### PR DESCRIPTION
### Added

- add `./blast.sh clean` command to preview and remove temporary cache and audio marker files after explicit `YES` confirmation
- add `CLAUDE.md` as a maintainer and application-integration guide that documents Seablast bootstrap, routing, model/view contracts, admin behavior, and current implementation caveats

### Changed

- harden `blast.sh` with `set -euo pipefail`, safe `--base-url` parsing and non-fatal cURL reachability warnings
- limit Latte `>=2.10.8 <3.1` as the implementation of filters differs between Latte 3.0 and 3.1

### Fixed

- suppress PHP/8.4 deprecation for `SeablastPdo::query()` by adding `#[\ReturnTypeWillChange]` while preserving PHP/7.2 compatibility
- avoid `Undefined array key "t"` warning in `AdminHelper::populateSelectedTable()` when no table is selected in the query string