### PR TITLE
feat: expose string[] SeablastConstant::ADMIN_BOOLEAN_FIELDS

### DIFF
--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -33,11 +33,12 @@ jobs:
     # Limit the running time
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # checkout PR HEAD commit
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0 # required for merge-base check
+          # required for merge-base check
+          fetch-depth: 0
           persist-credentials: false
       - uses: commit-check/commit-check-action@v2
         env:
@@ -54,7 +55,7 @@ jobs:
 
   # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.
   php-composer-unit-stan:
-    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.10
+    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.11
     with:
       # JSON
       php-version: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]'
@@ -95,11 +96,11 @@ jobs:
 
   super-linter:
     needs: phpcs-phpcbf
-    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.10
+    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.11
     with:
       # exclude third-party code
       filter-regex-exclude: ".*/assets/uls/.*"
       runs-on: "ubuntu-latest"
-      # todo fix fix assets/seablast.css and then allow again CSS validation
+      # todo fix assets/seablast.css and then allow again CSS validation
       validate-css: false
       validate-spell-codespell: true

--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -54,7 +54,7 @@ jobs:
 
   # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.
   php-composer-unit-stan:
-    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.9
+    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.10
     with:
       # JSON
       php-version: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]'
@@ -95,7 +95,7 @@ jobs:
 
   super-linter:
     needs: phpcs-phpcbf
-    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.9
+    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.10
     with:
       # exclude third-party code
       filter-regex-exclude: ".*/assets/uls/.*"

--- a/.gitignore
+++ b/.gitignore
@@ -4,13 +4,11 @@
 /log/*
 !/log/.htaccess
 /.composer-cache
-/.php_cs.cache
-/.php-cs-fixer.cache
-/.phpunit.result.cache
+/.*.cache
 /.sass-cache/
 
 #disable private local files
-*.local.php
+*.local.*
 
 #disable composer-managed libraries
 /vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,11 @@
 !/cache/.htaccess
 /log/*
 !/log/.htaccess
-/.sass-cache/
+/.composer-cache
 /.php_cs.cache
 /.php-cs-fixer.cache
 /.phpunit.result.cache
+/.sass-cache/
 
 #disable private local files
 *.local.php

--- a/.htaccess
+++ b/.htaccess
@@ -9,6 +9,8 @@ RewriteRule ^src(/|$) - [R=404,L]
 RedirectMatch 404 \/tests\/
 RedirectMatch 404 \/views\/
 # hide these files
+RedirectMatch 404 (^|/)composer\.(json|lock)$
+RedirectMatch 404 (^|/)\.phpunit\.result\.cache$
 RedirectMatch 404 phpstan\.neon\.dist
 RedirectMatch 404 phpunit\.xml
 # hide files with these extensions
@@ -17,4 +19,5 @@ RedirectMatch 404 \.neon$
 RedirectMatch 404 \.sh$
 RedirectMatch 404 \.yml$
 # hide all the files in any directory that have no filename but only an extension (like .prettierignore)
-RedirectMatch 404 /(\.[^.]+)$
+# hide all dotfiles in any directory, including multi-dot files like .phpunit.result.cache
+RedirectMatch 404 (^|/)\.[^/]+$

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,22 @@ The layout also:
 - loads `assets/scripts/seablast-bridge.js`
 - optionally includes Seablast I18n ULS assets when the i18n flag is active
 
+### Template CDN Security
+
+External scripts loaded from CDN must use Subresource Integrity (SRI) and
+`crossorigin="anonymous"`.
+
+SRI hashes are tied to the exact URL and response bytes that the browser loads,
+not only to the library name and version. For example, the official jQuery SRI
+snippet for `https://code.jquery.com/jquery-3.7.1.min.js` does not match the
+Google CDN URL currently used by `BlueprintWeb.latte`:
+
+- `https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js`
+
+If a CDN URL changes, recompute the SRI hash for the new URL from the raw
+downloaded bytes. Do not compute it from decoded text, because even subtle byte
+differences make the browser reject the script.
+
 ## Authentication and Authorization
 
 If `SeablastConstant::SB_IDENTITY_MANAGER` is configured, the controller instantiates the class with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# CLAUDE.md
+# AGENTS.md
 
 This file is the maintainer and integration guide for `seablast/seablast`.
 It is written for two audiences:
@@ -353,7 +353,7 @@ If a change affects framework behavior that applications depend on, update all o
 
 - `README.md` for public usage guidance
 - `CHANGELOG.md` for release notes
-- `CLAUDE.md` for maintainer and integration detail
+- `AGENTS.md` for maintainer and integration detail
 - tests where the behavior is asserted
 
 That keeps Seablast honest for both maintainers and downstream applications.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+feat: expose string[] SeablastConstant::ADMIN_BOOLEAN_FIELDS
+
 ### `Added` for new features
+
+- expose string[] SeablastConstant::ADMIN_BOOLEAN_FIELDS
 
 ### `Changed` for changes in existing functionality
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed` for changes in existing functionality
 
+- Introduce AGENTS.md and CLAUDE.md DRY combination
+
 ### `Deprecated` for soon-to-be removed features
 
 ### `Removed` for now removed features
@@ -18,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed` for any bugfixes
 
 - Fix PHPStan type inference for the bounded JSON API input read length.
+- Validate admin boolean-like columns against stored values before exposing boolean metadata.
+- Expose only true boolean-like admin column names to the table view model.
 
 ### `Security` in case of vulnerabilities
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed` for any bugfixes
 
+- Fix PHPStan type inference for the bounded JSON API input read length.
+
 ### `Security` in case of vulnerabilities
 
 - Harden JSON API input handling with content-type and body-size checks before decoding, and hide Composer/root dot metadata through Apache rules.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Security` in case of vulnerabilities
 
+- Harden JSON API input handling with content-type and body-size checks before decoding, and hide Composer/root dot metadata through Apache rules.
+
 ## [0.2.17.4] - 2026-05-03
 
 feat: allow up to 200 records listed in admin view

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-feat: expose string[] SeablastConstant::ADMIN_BOOLEAN_FIELDS
-
 ### `Added` for new features
 
-- expose string[] SeablastConstant::ADMIN_BOOLEAN_FIELDS
-
 ### `Changed` for changes in existing functionality
-
-- Introduce AGENTS.md and CLAUDE.md DRY combination
 
 ### `Deprecated` for soon-to-be removed features
 
@@ -23,13 +17,32 @@ feat: expose string[] SeablastConstant::ADMIN_BOOLEAN_FIELDS
 
 ### `Fixed` for any bugfixes
 
+### `Security` in case of vulnerabilities
+
+## [0.2.17.5] - 2026-06-28
+
+feat: expose string[] SeablastConstant::ADMIN_BOOLEAN_FIELDS
+
+### Added
+
+- expose string[] SeablastConstant::ADMIN_BOOLEAN_FIELDS
+
+### Changed
+
+- Introduce AGENTS.md and CLAUDE.md DRY combination
+- TableViewModel.php: change limit from 200 to 250 records to be listed in admin view
+- bump: Seablast Logger to v2.0.6
+
+### Fixed
+
 - Fix PHPStan type inference for the bounded JSON API input read length.
 - Validate admin boolean-like columns against stored values before exposing boolean metadata.
 - Expose only true boolean-like admin column names to the table view model.
 
-### `Security` in case of vulnerabilities
+### Security
 
 - Harden JSON API input handling with content-type and body-size checks before decoding, and hide Composer/root dot metadata through Apache rules.
+- Harden CDN script loading with SRI and document that hashes are tied to exact CDN response bytes.
 
 ## [0.2.17.4] - 2026-05-03
 
@@ -532,7 +545,8 @@ SeablastMysqli error logging improved, HTTPS identified
 - **model returns knowledge()**
 - a nice Under construction page
 
-[Unreleased]: https://github.com/WorkOfStan/seablast/compare/v0.2.17.4...HEAD?w=1
+[Unreleased]: https://github.com/WorkOfStan/seablast/compare/v0.2.17.5...HEAD?w=1
+[0.2.17.5]: https://github.com/WorkOfStan/seablast/compare/v0.2.17.4...v0.2.17.5?w=1
 [0.2.17.4]: https://github.com/WorkOfStan/seablast/compare/v0.2.17.3...v0.2.17.4?w=1
 [0.2.17.3]: https://github.com/WorkOfStan/seablast/compare/v0.2.17.2...v0.2.17.3?w=1
 [0.2.17.2]: https://github.com/WorkOfStan/seablast/compare/v0.2.17.1...v0.2.17.2?w=1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+# CLAUDE.md
+
+@AGENTS.md
+
+## Claude Code
+
+- Use plan mode before large refactors.
+- Prefer editing existing files over generating new abstractions unless justified.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,8 @@ Important consequences:
 Current behavior:
 
 - requires `REQUEST_METHOD` in `Superglobals->server`
+- for real HTTP input, requires JSON `Content-Type` before reading the body
+- rejects real or injected JSON input over 1 MiB before decoding
 - reads JSON from `php://input`, or from `SeablastConstant::JSON_INPUT` when injected for tests
 - accepts only a decoded JSON object
 - requires `csrfToken`
@@ -148,6 +150,8 @@ Default error behavior:
 
 - `400` for invalid JSON or wrong payload shape
 - `401` for missing or invalid CSRF token
+- `413` for JSON request bodies over 1 MiB
+- `415` for missing or non-JSON `Content-Type`
 
 Applications extending this class should call `parent::knowledge()` first and stop when it already returns `httpCode >= 400`.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Total Downloads](https://img.shields.io/packagist/dt/seablast/seablast.svg)](https://packagist.org/packages/seablast/seablast)
 [![Latest Stable Version](https://img.shields.io/packagist/v/seablast/seablast.svg)](https://packagist.org/packages/seablast/seablast)
+[![Polish the code](https://github.com/WorkOfStan/seablast/actions/workflows/polish-the-code.yml/badge.svg)](https://github.com/WorkOfStan/seablast/actions/workflows/polish-the-code.yml)
 
 This minimalist MVC framework added by [composer](https://getcomposer.org/) helps you to create a complex, yet easy to maintain, web application by configuration ONLY:
 

--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ This feature applies to all fields with the same name across all tables (field n
 ## Security
 
 All JSON calls and form submits MUST contain `csrfToken` handed over to the view layer in the `$csrfToken` string latte variable.
+JSON API calls using `GenericRestApiJsonModel` MUST send a JSON `Content-Type` header and stay within the default 1 MiB request body limit.
 
 ## Stack
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "php": ">=7.2 <8.6",
     "latte/latte": ">=2.10.8 <3.1",
     "nette/utils": "^3.2.10 || ^4.0.5 || ^4.1.0",
-    "seablast/interfaces": "dev-main",
+    "seablast/interfaces": "^0.1.3",
     "seablast/logger": "dev-feature/refactor2605",
     "symfony/security-csrf": "^4.4.37 || ^5 || ^6 || ^7 || ^8",
     "tracy/tracy": "^2.9.8 || ^2.10.9 || ^2.11.0",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "latte/latte": ">=2.10.8 <3.1",
     "nette/utils": "^3.2.10 || ^4.0.5 || ^4.1.0",
     "seablast/interfaces": "^0.1.3",
-    "seablast/logger": "dev-feature/refactor2605",
+    "seablast/logger": "dev-feature/refactor2606b",
     "symfony/security-csrf": "^4.4.37 || ^5 || ^6 || ^7 || ^8",
     "tracy/tracy": "^2.9.8 || ^2.10.9 || ^2.11.0",
     "webmozart/assert": "^1.10.0 || ^2.1.5"

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
     "php": ">=7.2 <8.6",
     "latte/latte": ">=2.10.8 <3.1",
     "nette/utils": "^3.2.10 || ^4.0.5 || ^4.1.0",
-    "seablast/interfaces": "^0.1.1",
-    "seablast/logger": "^1.0 || ^2.0.3",
+    "seablast/interfaces": "dev-main",
+    "seablast/logger": "dev-feature/refactor2605",
     "symfony/security-csrf": "^4.4.37 || ^5 || ^6 || ^7 || ^8",
     "tracy/tracy": "^2.9.8 || ^2.10.9 || ^2.11.0",
     "webmozart/assert": "^1.10.0 || ^2.1.5"

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "latte/latte": ">=2.10.8 <3.1",
     "nette/utils": "^3.2.10 || ^4.0.5 || ^4.1.0",
     "seablast/interfaces": "^0.1.3",
-    "seablast/logger": "dev-feature/refactor2606b",
+    "seablast/logger": "^2.0.6",
     "symfony/security-csrf": "^4.4.37 || ^5 || ^6 || ^7 || ^8",
     "tracy/tracy": "^2.9.8 || ^2.10.9 || ^2.11.0",
     "webmozart/assert": "^1.10.0 || ^2.1.5"

--- a/index.php
+++ b/index.php
@@ -34,10 +34,6 @@ $controller = new SeablastController($setup->getConfiguration(), $superglobals);
 $superglobals->setSession($_SESSION); // as only now the session started
 try {
     new SeablastView(new SeablastModel($controller, $superglobals));
-//} catch (\Seablast\Seablast\Exceptions\DbmsException $e) {
-//                // make sure that the database Tracy BarPanel is displayed when DbmsException is thrown
-//                $this->controller->getConfiguration()->showSqlBarPanel();
-//                throw new Exceptions\DbmsException($e->getMessage(), $e->getCode(), $e);
 } catch (\PDOException $e) {
     // make sure that the database Tracy BarPanel with error is displayed when PDOException is thrown
     $setup->getConfiguration()->pdo()->indicateDatabaseError();

--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -79,7 +79,7 @@ class AdminHelper
                 $tables = array_merge($tables, $this->configuration->getArrayString($permission . $suffix));
             }
         }
-        if ($this->configuration->getInt(SeablastConstant::SB_LOGGING_LEVEL) >= 5) { // Log as severity DEBUG
+        if ($this->configuration->getInt(SeablastConstant::SB_LOGGING_LEVEL) >= 5) { // Dump when severity DEBUG
             Debugger::barDump($tables, 'List of tables with permission: ' . $permission);
         }
         return $tables;

--- a/src/Admin/AdminModel.php
+++ b/src/Admin/AdminModel.php
@@ -72,7 +72,8 @@ class AdminModel implements SeablastModelInterface
                     $this->configuration->getString(SeablastConstant::APP_SELECTED_TABLE),
                     $this->adminHelper->getAllowedTables(SeablastConstant::ADMIN_TABLE_INSERT_ROW)
                 );
-                /* x* @phpstan-ignore staticMethod.alreadyNarrowedType */
+                Assert::isArray($knowledge['booleanLike']);
+                /* x* @phpstan-ignore staticMethod.alreadyNarrowedType */                
                 Assert::allString($knowledge['booleanLike']);
                 // TableViewModel produce it, admin.latte consumes it
                 $this->configuration->setArrayString(SeablastConstant::ADMIN_BOOLEAN_FIELDS, $knowledge['booleanLike']);

--- a/src/Admin/AdminModel.php
+++ b/src/Admin/AdminModel.php
@@ -59,7 +59,7 @@ class AdminModel implements SeablastModelInterface
                 $insertable = false;
             } else {
                 $knowledge = (array) $this->tableContent->knowledge();
-                $table =  $knowledge['table'];
+                $table = $knowledge['table'];
                 $columns = $knowledge['columns'];
                 $editable = $knowledge['editable'];
                 $conditionDetails = $knowledge['conditionDetails'];
@@ -71,6 +71,8 @@ class AdminModel implements SeablastModelInterface
                     $this->configuration->getString(SeablastConstant::APP_SELECTED_TABLE),
                     $this->adminHelper->getAllowedTables(SeablastConstant::ADMIN_TABLE_INSERT_ROW)
                 );
+                // TableViewModel produce it, admin.latte consumes it
+                $this->configuration->setArrayString(SeablastConstant::ADMIN_BOOLEAN_FIELDS, $knowledge['booleanLike']);
             }
 
             return (object) [

--- a/src/Admin/AdminModel.php
+++ b/src/Admin/AdminModel.php
@@ -73,7 +73,7 @@ class AdminModel implements SeablastModelInterface
                     $this->adminHelper->getAllowedTables(SeablastConstant::ADMIN_TABLE_INSERT_ROW)
                 );
                 /* x* @phpstan-ignore staticMethod.alreadyNarrowedType */
-                Assert::allInteger($knowledge['booleanLike']);
+                Assert::allString($knowledge['booleanLike']);
                 // TableViewModel produce it, admin.latte consumes it
                 $this->configuration->setArrayString(SeablastConstant::ADMIN_BOOLEAN_FIELDS, $knowledge['booleanLike']);
             }

--- a/src/Admin/AdminModel.php
+++ b/src/Admin/AdminModel.php
@@ -73,9 +73,8 @@ class AdminModel implements SeablastModelInterface
                     $this->adminHelper->getAllowedTables(SeablastConstant::ADMIN_TABLE_INSERT_ROW)
                 );
                 Assert::isArray($knowledge['booleanLike']);
-                /* x* @phpstan-ignore staticMethod.alreadyNarrowedType */
                 Assert::allString($knowledge['booleanLike']);
-                // TableViewModel produce it, admin.latte consumes it
+                // TableViewModel produces it, admin.latte consumes it
                 $this->configuration->setArrayString(SeablastConstant::ADMIN_BOOLEAN_FIELDS, $knowledge['booleanLike']);
             }
 

--- a/src/Admin/AdminModel.php
+++ b/src/Admin/AdminModel.php
@@ -73,7 +73,7 @@ class AdminModel implements SeablastModelInterface
                     $this->adminHelper->getAllowedTables(SeablastConstant::ADMIN_TABLE_INSERT_ROW)
                 );
                 Assert::isArray($knowledge['booleanLike']);
-                /* x* @phpstan-ignore staticMethod.alreadyNarrowedType */                
+                /* x* @phpstan-ignore staticMethod.alreadyNarrowedType */
                 Assert::allString($knowledge['booleanLike']);
                 // TableViewModel produce it, admin.latte consumes it
                 $this->configuration->setArrayString(SeablastConstant::ADMIN_BOOLEAN_FIELDS, $knowledge['booleanLike']);

--- a/src/Admin/AdminModel.php
+++ b/src/Admin/AdminModel.php
@@ -9,6 +9,7 @@ use Seablast\Seablast\SeablastConstant;
 use Seablast\Seablast\SeablastModelInterface;
 use Seablast\Seablast\Superglobals;
 use stdClass;
+use Webmozart\Assert\Assert;
 
 /**
  * Retrieve items from database

--- a/src/Admin/AdminModel.php
+++ b/src/Admin/AdminModel.php
@@ -71,6 +71,8 @@ class AdminModel implements SeablastModelInterface
                     $this->configuration->getString(SeablastConstant::APP_SELECTED_TABLE),
                     $this->adminHelper->getAllowedTables(SeablastConstant::ADMIN_TABLE_INSERT_ROW)
                 );
+                /* x* @phpstan-ignore staticMethod.alreadyNarrowedType */
+                Assert::allInteger($knowledge['booleanLike']);
                 // TableViewModel produce it, admin.latte consumes it
                 $this->configuration->setArrayString(SeablastConstant::ADMIN_BOOLEAN_FIELDS, $knowledge['booleanLike']);
             }

--- a/src/Admin/TableViewModel.php
+++ b/src/Admin/TableViewModel.php
@@ -221,6 +221,7 @@ WHERE
         // dev
         $foreignKeys = $this->foreignKeys($this->configuration->getString(SeablastConstant::APP_SELECTED_TABLE));
         Debugger::barDump($foreignKeys, 'foreignKeys');
+        // Boolean like columns uses a checkbox in the admin.latte
         $booleanLikeColumnNames = [];
         foreach (
             $this->booleanLikeColumns(

--- a/src/Admin/TableViewModel.php
+++ b/src/Admin/TableViewModel.php
@@ -73,10 +73,6 @@ class TableViewModel implements SeablastModelInterface
         return '`' . str_replace('`', '``', $identifier) . '`';
     }
 
-    /// compare to             $columnTypes = $this->adminHelper->columnTypes(
-    //                $this->configuration->getString(SeablastConstant::APP_SELECTED_TABLE)
-    //          );
-
     /**
      * Get boolean-like columns of a table.
      *
@@ -97,6 +93,10 @@ class TableViewModel implements SeablastModelInterface
 
         return $result;
     }
+
+    /// TODO compare to $columnTypes = $this->adminHelper->columnTypes(
+    //                $this->configuration->getString(SeablastConstant::APP_SELECTED_TABLE)
+    //          ); ... isn't there an opportunity for a DRY refactor?
 
     /**
      * Get information about table columns including their SQL type.
@@ -182,7 +182,7 @@ class TableViewModel implements SeablastModelInterface
      */
     private function foreignKeys(string $tableName): array
     {
-        //Query to List Foreign Keys in a Specific Table
+        // Query to List Foreign Keys in a Specific Table
         $query = "SELECT 
     TABLE_NAME, 
     COLUMN_NAME, 
@@ -313,7 +313,7 @@ WHERE
             . 'FROM `' . $this->configuration->dbmsTablePrefix()
             . $this->configuration->getString(SeablastConstant::APP_SELECTED_TABLE) . '` '
             . $sql
-            // todo allow paging
+            // todo allow paging instead of hard limit
             . ' LIMIT 0,250'
         );
         $data = [];

--- a/src/Admin/TableViewModel.php
+++ b/src/Admin/TableViewModel.php
@@ -214,13 +214,10 @@ WHERE
     public function knowledge(): stdClass
     {
         $cols = $this->adminHelper->getAllowedColumns();
-        Debugger::barDump($cols, 'cols');
         $columns = array_merge($cols['view'] ?? [], $cols['edit'] ?? []);
-        Debugger::barDump($columns, 'columns');
-
+    
         // dev
         $foreignKeys = $this->foreignKeys($this->configuration->getString(SeablastConstant::APP_SELECTED_TABLE));
-        Debugger::barDump($foreignKeys, 'foreignKeys');
         // Boolean like columns uses a checkbox in the admin.latte
         $booleanLikeColumnNames = [];
         foreach (
@@ -231,6 +228,12 @@ WHERE
             if ($isBooleanLike) {
                 $booleanLikeColumnNames[] = $columnName;
             }
+        }
+        if ($this->configuration->getInt(SeablastConstant::SB_LOGGING_LEVEL) >= 5) { // Log as severity DEBUG        
+            Debugger::barDump($cols, 'cols');
+            Debugger::barDump($columns, 'columns');
+            Debugger::barDump($foreignKeys, 'foreignKeys'); // dev    
+            Debugger::barDump($booleanLikeColumnNames, 'booleanLike');
         }
         // Get order and conditions from GET parameters
         $order = isset($this->superglobals->get['order']) ? $this->superglobals->get['order'] : '';

--- a/src/Admin/TableViewModel.php
+++ b/src/Admin/TableViewModel.php
@@ -68,6 +68,11 @@ class TableViewModel implements SeablastModelInterface
         return array(substr($string, 0, $position), substr($string, $position + 1));
     }
 
+    private function escapeIdentifier(string $identifier): string
+    {
+        return '`' . str_replace('`', '``', $identifier) . '`';
+    }
+
     /// compare to             $columnTypes = $this->adminHelper->columnTypes(
     //                $this->configuration->getString(SeablastConstant::APP_SELECTED_TABLE)
     //          );
@@ -118,21 +123,52 @@ class TableViewModel implements SeablastModelInterface
 
         $result = $this->configuration->mysqli()->query($query);
         $columnTypes = [];
+        $booleanLikeColumnIndexes = [];
 
         if ($result && is_object($result)) {
             while ($row = $result->fetch_assoc()) {
                 $columnType = isset($row['COLUMN_TYPE']) ? strtolower((string) $row['COLUMN_TYPE']) : '';
                 $dataType = isset($row['DATA_TYPE']) ? strtolower((string) $row['DATA_TYPE']) : '';
-
-                $row['IS_BOOLEAN_LIKE'] = (
+                Assert::scalar($row['COLUMN_NAME']);
+                $columnName = (string) $row['COLUMN_NAME'];
+                $isBooleanLike = (
                     $columnType === 'tinyint(1)' || $columnType === 'tinyint(1) unsigned' || $columnType === 'bit(1)' //
                     || $dataType === 'boolean' || $dataType === 'bool'
-                    ) ? 1 : 0;
+                );
+                $row['IS_BOOLEAN_LIKE'] = $isBooleanLike ? 1 : 0;
+                if ($isBooleanLike) {
+                    $booleanLikeColumnIndexes[$columnName] = count($columnTypes);
+                }
 
                 $columnTypes[] = $row;
             }
 
             $result->free();
+        }
+
+        if (!empty($booleanLikeColumnIndexes)) {
+            $checks = [];
+            foreach (array_keys($booleanLikeColumnIndexes) as $i => $columnName) {
+                $checks[] = 'COALESCE(MIN(' . $this->escapeIdentifier($columnName)
+                    . ' IS NULL OR ' . $this->escapeIdentifier($columnName)
+                    . ' IN (0,1)), 1) AS ' . $this->escapeIdentifier('b' . $i);
+            }
+
+            $booleanCheckResult = $this->configuration->mysqli()->query(
+                'SELECT ' . implode(', ', $checks)
+                . ' FROM ' . $this->escapeIdentifier($fullTableName)
+            );
+
+            if ($booleanCheckResult && is_object($booleanCheckResult)) {
+                $booleanCheckRow = $booleanCheckResult->fetch_assoc();
+                if (is_array($booleanCheckRow)) {
+                    foreach (array_keys($booleanLikeColumnIndexes) as $i => $columnName) {
+                        $columnTypes[$booleanLikeColumnIndexes[$columnName]]['IS_BOOLEAN_LIKE'] =
+                            !empty($booleanCheckRow['b' . $i]) ? 1 : 0;
+                    }
+                }
+                $booleanCheckResult->free();
+            }
         }
 
         return $columnTypes;
@@ -185,10 +221,14 @@ WHERE
         // dev
         $foreignKeys = $this->foreignKeys($this->configuration->getString(SeablastConstant::APP_SELECTED_TABLE));
         Debugger::barDump($foreignKeys, 'foreignKeys');
-        Debugger::barDump(
-            $this->booleanLikeColumns($this->configuration->getString(SeablastConstant::APP_SELECTED_TABLE)),
-            'boolean like'
-        );
+        $booleanLikeColumnNames = [];
+        foreach ($this->booleanLikeColumns(
+            $this->configuration->getString(SeablastConstant::APP_SELECTED_TABLE)
+        ) as $columnName => $isBooleanLike) {
+            if ($isBooleanLike) {
+                $booleanLikeColumnNames[] = $columnName;
+            }
+        }
         // Get order and conditions from GET parameters
         $order = isset($this->superglobals->get['order']) ? $this->superglobals->get['order'] : '';
         $conditions = [];
@@ -268,7 +308,7 @@ WHERE
             . $this->configuration->getString(SeablastConstant::APP_SELECTED_TABLE) . '` '
             . $sql
             // todo allow paging
-            . ' LIMIT 0,200'
+            . ' LIMIT 0,250'
         );
         $data = [];
         // Fetch each row and add it to the $data array
@@ -283,6 +323,7 @@ WHERE
                 'columns' => $columns,
                 'editable' => $cols['edit'] ?? [],
                 'conditionDetails' => $conditionDetails,
+                'booleanLike' => $booleanLikeColumnNames,
                 // data
                 'table' => $data,
         ];

--- a/src/Admin/TableViewModel.php
+++ b/src/Admin/TableViewModel.php
@@ -229,7 +229,7 @@ WHERE
                 $booleanLikeColumnNames[] = $columnName;
             }
         }
-        if ($this->configuration->getInt(SeablastConstant::SB_LOGGING_LEVEL) >= 5) { // Log as severity DEBUG        
+        if ($this->configuration->getInt(SeablastConstant::SB_LOGGING_LEVEL) >= 4) { // Dump when severity INFO
             Debugger::barDump($cols, 'cols');
             Debugger::barDump($columns, 'columns');
             Debugger::barDump($foreignKeys, 'foreignKeys'); // dev    

--- a/src/Admin/TableViewModel.php
+++ b/src/Admin/TableViewModel.php
@@ -215,7 +215,7 @@ WHERE
     {
         $cols = $this->adminHelper->getAllowedColumns();
         $columns = array_merge($cols['view'] ?? [], $cols['edit'] ?? []);
-    
+
         // dev
         $foreignKeys = $this->foreignKeys($this->configuration->getString(SeablastConstant::APP_SELECTED_TABLE));
         // Boolean like columns uses a checkbox in the admin.latte
@@ -232,7 +232,7 @@ WHERE
         if ($this->configuration->getInt(SeablastConstant::SB_LOGGING_LEVEL) >= 4) { // Dump when severity INFO
             Debugger::barDump($cols, 'cols');
             Debugger::barDump($columns, 'columns');
-            Debugger::barDump($foreignKeys, 'foreignKeys'); // dev    
+            Debugger::barDump($foreignKeys, 'foreignKeys'); // dev
             Debugger::barDump($booleanLikeColumnNames, 'booleanLike');
         }
         // Get order and conditions from GET parameters

--- a/src/Admin/TableViewModel.php
+++ b/src/Admin/TableViewModel.php
@@ -222,9 +222,11 @@ WHERE
         $foreignKeys = $this->foreignKeys($this->configuration->getString(SeablastConstant::APP_SELECTED_TABLE));
         Debugger::barDump($foreignKeys, 'foreignKeys');
         $booleanLikeColumnNames = [];
-        foreach ($this->booleanLikeColumns(
-            $this->configuration->getString(SeablastConstant::APP_SELECTED_TABLE)
-        ) as $columnName => $isBooleanLike) {
+        foreach (
+            $this->booleanLikeColumns(
+                $this->configuration->getString(SeablastConstant::APP_SELECTED_TABLE)
+            ) as $columnName => $isBooleanLike
+        ) {
             if ($isBooleanLike) {
                 $booleanLikeColumnNames[] = $columnName;
             }

--- a/src/Apis/GenericRestApiJsonModel.php
+++ b/src/Apis/GenericRestApiJsonModel.php
@@ -23,6 +23,9 @@ class GenericRestApiJsonModel implements SeablastModelInterface
 {
     use \Nette\SmartObject;
 
+    /** @var int Maximum JSON request body size in bytes */
+    protected const JSON_INPUT_MAX_BYTES = 1048576;
+
     /** @ var array<mixed> Resulting knowledge. */
     //todo move to SBdist//private $businessLogicResult;
 
@@ -88,15 +91,30 @@ class GenericRestApiJsonModel implements SeablastModelInterface
      */
     private function processInput(): void
     {
+        $jsonInputInjected = $this->configuration->exists(SeablastConstant::JSON_INPUT);
+        if (!$jsonInputInjected) {
+            if ($this->contentLengthExceedsLimit()) {
+                $this->rejectInput(413, 'JSON input exceeds the maximum allowed size.');
+                return;
+            }
+            if (!$this->hasJsonContentType()) {
+                $this->rejectInput(415, 'Unsupported content type.');
+                return;
+            }
+        }
         // Read JSON from standard input if not pre-prepared
-        $jsonInput = $this->configuration->exists(SeablastConstant::JSON_INPUT)
+        $jsonInput = $jsonInputInjected
             ? $this->configuration->getString(SeablastConstant::JSON_INPUT)
-            : file_get_contents('php://input');
+            : $this->readJsonInput();
         if (!is_string($jsonInput)) {
             Debugger::barDump(["Either JSON_INPUT or php://input isn't string", $jsonInput], 'ERROR on input');
             Debugger::log("Either JSON_INPUT or php://input isn't string", ILogger::ERROR);
             $this->httpCode = 400; // Bad Request
             $this->message = 'Invalid input';
+            return;
+        }
+        if (strlen($jsonInput) > static::JSON_INPUT_MAX_BYTES) {
+            $this->rejectInput(413, 'JSON input exceeds the maximum allowed size.');
             return;
         }
         $jsonDecoded = json_decode($jsonInput);
@@ -168,6 +186,78 @@ class GenericRestApiJsonModel implements SeablastModelInterface
             $this->message = 'CSRF token mismatch';
             return;
         }
+    }
+
+    /**
+     * Checks whether the announced request body size is too large.
+     *
+     * @return bool
+     */
+    private function contentLengthExceedsLimit(): bool
+    {
+        if (!isset($this->superglobals->server['CONTENT_LENGTH'])) {
+            return false;
+        }
+        if (!is_scalar($this->superglobals->server['CONTENT_LENGTH'])) {
+            return false;
+        }
+        $contentLength = trim((string) $this->superglobals->server['CONTENT_LENGTH']);
+        if ($contentLength === '' || !ctype_digit($contentLength)) {
+            return false;
+        }
+        return (int) $contentLength > static::JSON_INPUT_MAX_BYTES;
+    }
+
+    /**
+     * Checks whether request Content-Type is JSON.
+     *
+     * @return bool
+     */
+    private function hasJsonContentType(): bool
+    {
+        $contentType = $this->superglobals->server['CONTENT_TYPE']
+            ?? $this->superglobals->server['HTTP_CONTENT_TYPE']
+            ?? '';
+        if (!is_scalar($contentType)) {
+            return false;
+        }
+        $mediaTypeParts = explode(';', (string) $contentType, 2);
+        $mediaType = strtolower(trim($mediaTypeParts[0]));
+        if ($mediaType === 'application/json') {
+            return true;
+        }
+        return strpos($mediaType, '/') !== false && substr($mediaType, -5) === '+json';
+    }
+
+    /**
+     * Read only the maximum accepted JSON bytes plus one byte to detect overflow.
+     *
+     * @return string|false
+     */
+    private function readJsonInput()
+    {
+        $stream = fopen('php://input', 'rb');
+        if ($stream === false) {
+            return false;
+        }
+        $jsonInput = fread($stream, static::JSON_INPUT_MAX_BYTES + 1);
+        fclose($stream);
+        return $jsonInput;
+    }
+
+    /**
+     * Populate a generic API validation error.
+     *
+     * @param int $httpCode
+     * @param string $message
+     * @return void
+     */
+    private function rejectInput(int $httpCode, string $message): void
+    {
+        Debugger::barDump($message, 'ERROR on input');
+        Debugger::log($message, ILogger::ERROR);
+        $this->httpCode = $httpCode;
+        $this->message = $message;
     }
 
     /**

--- a/src/Apis/GenericRestApiJsonModel.php
+++ b/src/Apis/GenericRestApiJsonModel.php
@@ -240,7 +240,9 @@ class GenericRestApiJsonModel implements SeablastModelInterface
         if ($stream === false) {
             return false;
         }
-        $jsonInput = fread($stream, static::JSON_INPUT_MAX_BYTES + 1);
+        $readLength = static::JSON_INPUT_MAX_BYTES + 1;
+        Assert::greaterThanEq($readLength, 1);
+        $jsonInput = fread($stream, $readLength);
         fclose($stream);
         return $jsonInput;
     }

--- a/src/SeablastConstant.php
+++ b/src/SeablastConstant.php
@@ -179,6 +179,10 @@ class SeablastConstant
      */
     public const USER_GROUPS = 'SB:USER_GROUPS';
     /**
+     * @var string string[] list of fields that are boolean, hence should be represented by a checkbox
+     */
+    public const ADMIN_BOOLEAN_FIELDS = 'SB:ADMIN_BOOLEAN_FIELDS';
+    /**
      * @var string string[] list of fields that contain color, so that input type color is better than textarea
      */
     public const ADMIN_COLOR_FIELDS = 'SB:ADMIN_COLOR_FIELDS';

--- a/tests/GenericRestApiJsonModelTest.php
+++ b/tests/GenericRestApiJsonModelTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Seablast\Seablast\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Seablast\Seablast\Apis\GenericRestApiJsonModel;
+use Seablast\Seablast\SeablastConfiguration;
+use Seablast\Seablast\SeablastConstant;
+use Seablast\Seablast\Superglobals;
+use stdClass;
+use Tracy\Debugger;
+
+class GenericRestApiJsonModelTest extends TestCase
+{
+    private const JSON_INPUT_MAX_BYTES = 1048576;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (!defined('APP_DIR')) {
+            define('APP_DIR', __DIR__ . '/..');
+            Debugger::enable(Debugger::DEVELOPMENT, APP_DIR . '/log');
+        }
+    }
+
+    public function testInjectedJsonUnderLimitReachesCsrfValidation(): void
+    {
+        $knowledge = $this->knowledgeForInjectedJson('{}');
+
+        $this->assertSame(401, $knowledge->httpCode);
+        $this->assertSame('CSRF token missing', $knowledge->rest->message);
+    }
+
+    public function testInjectedJsonOverLimitReturnsPayloadTooLarge(): void
+    {
+        $knowledge = $this->knowledgeForInjectedJson(str_repeat(' ', self::JSON_INPUT_MAX_BYTES + 1));
+
+        $this->assertSame(413, $knowledge->httpCode);
+        $this->assertSame('JSON input exceeds the maximum allowed size.', $knowledge->rest->message);
+    }
+
+    public function testUnsupportedContentTypeReturnsUnsupportedMediaType(): void
+    {
+        $knowledge = $this->knowledgeForServer([
+            'CONTENT_TYPE' => 'text/plain',
+        ]);
+
+        $this->assertSame(415, $knowledge->httpCode);
+        $this->assertSame('Unsupported content type.', $knowledge->rest->message);
+    }
+
+    public function testMissingContentTypeReturnsUnsupportedMediaType(): void
+    {
+        $knowledge = $this->knowledgeForServer();
+
+        $this->assertSame(415, $knowledge->httpCode);
+        $this->assertSame('Unsupported content type.', $knowledge->rest->message);
+    }
+
+    public function testStructuredJsonContentTypeWithParametersIsAccepted(): void
+    {
+        $knowledge = $this->knowledgeForServer([
+            'CONTENT_TYPE' => 'application/problem+json; charset=utf-8',
+        ]);
+
+        $this->assertSame(400, $knowledge->httpCode);
+        $this->assertSame('Syntax error', $knowledge->rest->message);
+    }
+
+    public function testContentLengthOverLimitReturnsPayloadTooLarge(): void
+    {
+        $knowledge = $this->knowledgeForServer([
+            'CONTENT_TYPE' => 'application/json',
+            'CONTENT_LENGTH' => (string) (self::JSON_INPUT_MAX_BYTES + 1),
+        ]);
+
+        $this->assertSame(413, $knowledge->httpCode);
+        $this->assertSame('JSON input exceeds the maximum allowed size.', $knowledge->rest->message);
+    }
+
+    public function testMalformedJsonUnderLimitKeepsExistingParseError(): void
+    {
+        $knowledge = $this->knowledgeForInjectedJson('{');
+
+        $this->assertSame(400, $knowledge->httpCode);
+        $this->assertSame('Syntax error', $knowledge->rest->message);
+    }
+
+    private function knowledgeForInjectedJson(string $jsonInput): stdClass
+    {
+        $configuration = new SeablastConfiguration();
+        $configuration->setString(SeablastConstant::JSON_INPUT, $jsonInput);
+
+        $model = new GenericRestApiJsonModel(
+            $configuration,
+            new Superglobals([], [], ['REQUEST_METHOD' => 'POST'])
+        );
+
+        return $model->knowledge();
+    }
+
+    /**
+     * @param array<string, string> $server
+     */
+    private function knowledgeForServer(array $server = []): stdClass
+    {
+        $model = new GenericRestApiJsonModel(
+            new SeablastConfiguration(),
+            new Superglobals([], [], array_merge(['REQUEST_METHOD' => 'POST'], $server))
+        );
+
+        return $model->knowledge();
+    }
+}

--- a/tests/GenericRestApiJsonModelTest.php
+++ b/tests/GenericRestApiJsonModelTest.php
@@ -29,16 +29,14 @@ class GenericRestApiJsonModelTest extends TestCase
     {
         $knowledge = $this->knowledgeForInjectedJson('{}');
 
-        $this->assertSame(401, $knowledge->httpCode);
-        $this->assertSame('CSRF token missing', $knowledge->rest->message);
+        $this->assertRestResponse($knowledge, 401, 'CSRF token missing');
     }
 
     public function testInjectedJsonOverLimitReturnsPayloadTooLarge(): void
     {
         $knowledge = $this->knowledgeForInjectedJson(str_repeat(' ', self::JSON_INPUT_MAX_BYTES + 1));
 
-        $this->assertSame(413, $knowledge->httpCode);
-        $this->assertSame('JSON input exceeds the maximum allowed size.', $knowledge->rest->message);
+        $this->assertRestResponse($knowledge, 413, 'JSON input exceeds the maximum allowed size.');
     }
 
     public function testUnsupportedContentTypeReturnsUnsupportedMediaType(): void
@@ -47,16 +45,14 @@ class GenericRestApiJsonModelTest extends TestCase
             'CONTENT_TYPE' => 'text/plain',
         ]);
 
-        $this->assertSame(415, $knowledge->httpCode);
-        $this->assertSame('Unsupported content type.', $knowledge->rest->message);
+        $this->assertRestResponse($knowledge, 415, 'Unsupported content type.');
     }
 
     public function testMissingContentTypeReturnsUnsupportedMediaType(): void
     {
         $knowledge = $this->knowledgeForServer();
 
-        $this->assertSame(415, $knowledge->httpCode);
-        $this->assertSame('Unsupported content type.', $knowledge->rest->message);
+        $this->assertRestResponse($knowledge, 415, 'Unsupported content type.');
     }
 
     public function testStructuredJsonContentTypeWithParametersIsAccepted(): void
@@ -65,8 +61,7 @@ class GenericRestApiJsonModelTest extends TestCase
             'CONTENT_TYPE' => 'application/problem+json; charset=utf-8',
         ]);
 
-        $this->assertSame(400, $knowledge->httpCode);
-        $this->assertSame('Syntax error', $knowledge->rest->message);
+        $this->assertRestResponse($knowledge, 400, 'Syntax error');
     }
 
     public function testContentLengthOverLimitReturnsPayloadTooLarge(): void
@@ -76,16 +71,22 @@ class GenericRestApiJsonModelTest extends TestCase
             'CONTENT_LENGTH' => (string) (self::JSON_INPUT_MAX_BYTES + 1),
         ]);
 
-        $this->assertSame(413, $knowledge->httpCode);
-        $this->assertSame('JSON input exceeds the maximum allowed size.', $knowledge->rest->message);
+        $this->assertRestResponse($knowledge, 413, 'JSON input exceeds the maximum allowed size.');
     }
 
     public function testMalformedJsonUnderLimitKeepsExistingParseError(): void
     {
         $knowledge = $this->knowledgeForInjectedJson('{');
 
-        $this->assertSame(400, $knowledge->httpCode);
-        $this->assertSame('Syntax error', $knowledge->rest->message);
+        $this->assertRestResponse($knowledge, 400, 'Syntax error');
+    }
+
+    private function assertRestResponse(stdClass $knowledge, int $httpCode, string $message): void
+    {
+        $this->assertSame($httpCode, $knowledge->httpCode);
+        $rest = $knowledge->rest;
+        $this->assertInstanceOf(stdClass::class, $rest);
+        $this->assertSame($message, $rest->message);
     }
 
     private function knowledgeForInjectedJson(string $jsonInput): stdClass

--- a/tests/TemplateSecurityTest.php
+++ b/tests/TemplateSecurityTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Seablast\Seablast\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class TemplateSecurityTest extends TestCase
+{
+    public function testExternalScriptTagsUseSriAndAnonymousCors(): void
+    {
+        $templateDirectory = __DIR__ . '/../views';
+        $templateFiles = glob($templateDirectory . '/*.latte');
+        $this->assertNotFalse($templateFiles, 'Should be able to list bundled Latte templates.');
+
+        $expectedIntegrityByUrl = [
+            'https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js' => 'sha384-1H217gwSVyLSIfaLxHbE7dRb3v4mYCKbpQvzx0cegeju1MVsGrX5xXxAvs/HgeFs',
+            'https://cdn.jsdelivr.net/gh/e3rd/WebHotkeys@0.9.4/WebHotkeys.js?register' => 'sha384-VtSHOatDaywsjcaoV86liUBBl28v5GV/w+ee6ls5ZXHWpbjiI2QuMc/r+JEYDILa',
+        ];
+        $externalScriptTagCount = 0;
+
+        foreach ($templateFiles as $templateFile) {
+            $template = file_get_contents($templateFile);
+            $this->assertNotFalse($template, sprintf('Should be able to read %s.', $templateFile));
+
+            preg_match_all('/<script\b(?=[^>]*\bsrc="(https:\/\/[^"]+)")[^>]*>/i', $template, $matches, PREG_SET_ORDER);
+
+            foreach ($matches as $match) {
+                ++$externalScriptTagCount;
+                $scriptTag = $match[0];
+                $scriptUrl = $match[1];
+                $this->assertSame(
+                    1,
+                    preg_match('/\bintegrity="sha384-[A-Za-z0-9+\/=]+"/', $scriptTag),
+                    sprintf('External script tag in %s must use sha384 SRI: %s', basename($templateFile), $scriptTag)
+                );
+                $this->assertStringContainsString(
+                    'crossorigin="anonymous"',
+                    $scriptTag,
+                    sprintf('External script tag in %s must use anonymous CORS: %s', basename($templateFile), $scriptTag)
+                );
+                if (array_key_exists($scriptUrl, $expectedIntegrityByUrl)) {
+                    $this->assertStringContainsString(
+                        sprintf('integrity="%s"', $expectedIntegrityByUrl[$scriptUrl]),
+                        $scriptTag,
+                        sprintf('External script tag in %s must use the expected SRI hash: %s', basename($templateFile), $scriptTag)
+                    );
+                }
+            }
+        }
+
+        $this->assertGreaterThan(0, $externalScriptTagCount, 'Should find bundled external script tags to validate.');
+    }
+}

--- a/tests/TemplateSecurityTest.php
+++ b/tests/TemplateSecurityTest.php
@@ -41,7 +41,9 @@ class TemplateSecurityTest extends TestCase
                     'crossorigin="anonymous"',
                     $scriptTag,
                     sprintf(
-                        'External script tag in %s must use anonymous CORS: %s', basename($templateFile), $scriptTag
+                        'External script tag in %s must use anonymous CORS: %s',
+                        basename($templateFile),
+                        $scriptTag
                     )
                 );
                 if (array_key_exists($scriptUrl, $expectedIntegrityByUrl)) {
@@ -49,8 +51,8 @@ class TemplateSecurityTest extends TestCase
                         sprintf('integrity="%s"', $expectedIntegrityByUrl[$scriptUrl]),
                         $scriptTag,
                         sprintf(
-                            'External script tag in %s must use the expected SRI hash: %s', 
-                            basename($templateFile), 
+                            'External script tag in %s must use the expected SRI hash: %s',
+                            basename($templateFile),
                             $scriptTag
                         )
                     );

--- a/tests/TemplateSecurityTest.php
+++ b/tests/TemplateSecurityTest.php
@@ -15,8 +15,10 @@ class TemplateSecurityTest extends TestCase
         $this->assertNotFalse($templateFiles, 'Should be able to list bundled Latte templates.');
 
         $expectedIntegrityByUrl = [
-            'https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js' => 'sha384-1H217gwSVyLSIfaLxHbE7dRb3v4mYCKbpQvzx0cegeju1MVsGrX5xXxAvs/HgeFs',
-            'https://cdn.jsdelivr.net/gh/e3rd/WebHotkeys@0.9.4/WebHotkeys.js?register' => 'sha384-VtSHOatDaywsjcaoV86liUBBl28v5GV/w+ee6ls5ZXHWpbjiI2QuMc/r+JEYDILa',
+            'https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js' => //
+            'sha384-1H217gwSVyLSIfaLxHbE7dRb3v4mYCKbpQvzx0cegeju1MVsGrX5xXxAvs/HgeFs',
+            'https://cdn.jsdelivr.net/gh/e3rd/WebHotkeys@0.9.4/WebHotkeys.js?register' => //
+            'sha384-VtSHOatDaywsjcaoV86liUBBl28v5GV/w+ee6ls5ZXHWpbjiI2QuMc/r+JEYDILa',
         ];
         $externalScriptTagCount = 0;
 
@@ -38,13 +40,19 @@ class TemplateSecurityTest extends TestCase
                 $this->assertStringContainsString(
                     'crossorigin="anonymous"',
                     $scriptTag,
-                    sprintf('External script tag in %s must use anonymous CORS: %s', basename($templateFile), $scriptTag)
+                    sprintf(
+                        'External script tag in %s must use anonymous CORS: %s', basename($templateFile), $scriptTag
+                    )
                 );
                 if (array_key_exists($scriptUrl, $expectedIntegrityByUrl)) {
                     $this->assertStringContainsString(
                         sprintf('integrity="%s"', $expectedIntegrityByUrl[$scriptUrl]),
                         $scriptTag,
-                        sprintf('External script tag in %s must use the expected SRI hash: %s', basename($templateFile), $scriptTag)
+                        sprintf(
+                            'External script tag in %s must use the expected SRI hash: %s', 
+                            basename($templateFile), 
+                            $scriptTag
+                        )
                     );
                 }
             }

--- a/views/BlueprintWeb.latte
+++ b/views/BlueprintWeb.latte
@@ -20,7 +20,7 @@
             ];
         </script>
         {* jQuery is required if 'I18n:SHOW_LANGUAGE_SELECTOR' and for admin.latte, therefore it's linked by default. If you want ultraminimalist blueprint without jQuery, use your own within your app *}
-        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>{* MUST be before send-auth-token and other scripts referred to within mainblock *}
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js" integrity="sha384-1H217gwSVyLSIfaLxHbE7dRb3v4mYCKbpQvzx0cegeju1MVsGrX5xXxAvs/HgeFs" crossorigin="anonymous"></script>{* MUST be before send-auth-token and other scripts referred to within mainblock *}
         <script type="module" src="{$configuration->getString('SB_APP_ROOT_ABSOLUTE_URL')}/vendor/seablast/seablast/assets/scripts/seablast-bridge.js?v={$configuration->getInt('SB_WEB_FORCE_ASSET_VERSION')}"></script> {* so that seablast objects are ready before app code *}
         <header>
             <nav>

--- a/views/admin.latte
+++ b/views/admin.latte
@@ -122,7 +122,7 @@
 <script type="module" src="{$configuration->getString('SB_APP_ROOT_ABSOLUTE_URL')}/vendor/seablast/seablast/assets/scripts/seablast-bridge.js?v={$configuration->getInt('SB_WEB_FORCE_ASSET_VERSION')}"></script>
 {* scripts using seablast objects MUST use defer, so that the expected objects are already defined *}
 <script defer src="{$configuration->getString('SB_APP_ROOT_ABSOLUTE_URL')}/vendor/seablast/seablast/assets/scripts/mit.js?v={$configuration->getInt('SB_WEB_FORCE_ASSET_VERSION')}"></script> {* initEditable(); *}
-<script src="https://cdn.jsdelivr.net/gh/e3rd/WebHotkeys@0.9.4/WebHotkeys.js?register"></script>
+<script src="https://cdn.jsdelivr.net/gh/e3rd/WebHotkeys@0.9.4/WebHotkeys.js?register" integrity="sha384-VtSHOatDaywsjcaoV86liUBBl28v5GV/w+ee6ls5ZXHWpbjiI2QuMc/r+JEYDILa" crossorigin="anonymous"></script>
 <script> {* todo make this an external js *}
     $(document).ready(function () {
 


### PR DESCRIPTION
### Added

- expose string[] SeablastConstant::ADMIN_BOOLEAN_FIELDS

### Changed

- Introduce AGENTS.md and CLAUDE.md DRY combination
- TableViewModel.php: change limit from 200 to 250 records to be listed in admin view
- bump: Seablast Logger to v2.0.6

### Fixed

- Fix PHPStan type inference for the bounded JSON API input read length.
- Validate admin boolean-like columns against stored values before exposing boolean metadata.
- Expose only true boolean-like admin column names to the table view model.

### Security

- Harden JSON API input handling with content-type and body-size checks before decoding, and hide Composer/root dot metadata through Apache rules.
- Harden CDN script loading with SRI and document that hashes are tied to exact CDN response bytes.