### PR TITLE
docs: add `AGENT-STARTER-KIT.md` as an application-builder guide

### DIFF
--- a/AGENT-STARTER-KIT.md
+++ b/AGENT-STARTER-KIT.md
@@ -1,0 +1,217 @@
+# AGENT-STARTER-KIT.md
+
+This file is for AI agents building or migrating applications that use Seablast for PHP.
+Use it when Seablast is a dependency in another project.
+
+For framework maintenance inside `seablast/seablast`, read `AGENTS.md` instead.
+
+## What To Build With Seablast
+
+Seablast is a composer-installed MVC runtime for vanilla PHP applications.
+It works best when the app keeps business code simple and explicit:
+
+- configuration in `conf/app.conf.php`
+- route declarations in `SeablastConstant::APP_MAPPING`
+- models in `src/Models/`
+- Latte templates in `views/`
+- browser assets in `assets/`
+- runtime write directories such as `cache/` and `log/`
+- private app storage in a non-public directory such as `var/`
+
+For new projects, start from `seablast-dist` when possible and remove demo code deliberately.
+For existing app migrations, reshape the app into the Seablast structure instead of keeping a parallel framework layout alive.
+
+## Bootstrap And Project Shape
+
+Normal web requests should enter through:
+
+```txt
+vendor/seablast/seablast/index.php
+```
+
+The app root should not keep a competing front controller unless the project has a deliberate replacement for the Seablast runtime.
+`defineAppDir.php` resolves `APP_DIR` from the vendor layout, so app code can rely on `APP_DIR` during Seablast web requests.
+
+The app-level configuration files are:
+
+- `conf/app.conf.php` for committed app configuration
+- `conf/app.conf.local.php` for uncommitted environment overrides
+- `conf/phinx.local.php` for Seablast's built-in MySQL adapters
+
+Each Seablast config file returns a callable that receives `SeablastConfiguration`.
+
+## Routing
+
+Routes are exact path matches. Seablast does not choose a different model by HTTP method at the mapping layer.
+
+Use one of these styles:
+
+- separate exact paths for separate actions, for example `/invoice`, `/invoice/edit`, `/api/invoice`
+- one resource path with a model that branches on `REQUEST_METHOD`, query parameters, or POST data
+
+Route keys used by core:
+
+```php
+->setArrayArrayString(
+    SeablastConstant::APP_MAPPING,
+    '/example',
+    [
+        'model' => '\App\Models\ExampleModel',
+        'template' => 'example',
+        'roleIds' => '1,2',
+        'id' => 'id',
+        'code' => 'code',
+    ]
+)
+```
+
+Important route behavior:
+
+- one route mapping has one `template`
+- trailing slashes are trimmed
+- an empty path becomes `/`
+- missing routes render `/error`
+- `id` and `code` mapping keys make the matching GET parameter required
+- optional `?id=` or mixed list/detail behavior must be validated inside the model
+- protected routes need a configured identity manager
+
+## Models And Responses
+
+Application models should match `SeablastModelInterface`:
+
+```php
+public function __construct(
+    SeablastConfiguration $configuration,
+    Superglobals $superglobals
+) {
+}
+
+public function knowledge(): stdClass
+{
+}
+```
+
+Return an `stdClass`, not an array.
+Seablast adds `csrfToken` after the model runs.
+
+Special response properties:
+
+- `rest`: render JSON instead of HTML
+- `httpCode`: set the response status
+- `redirectionUrl`: send a redirect and render `redirection.latte`
+- `title`: used by the default `BlueprintWeb.latte` page title
+
+Redirect status codes are limited to `301`, `302`, `303`, `307`, and `308`.
+Prefer app-relative redirect URLs unless a trusted external host is explicitly allowed.
+
+## Templates And Assets
+
+With the default `LATTE_TEMPLATE = 'views'`, app templates live in `APP_DIR/views/*.latte`.
+A typical app template extends the bundled layout:
+
+```latte
+{layout '../vendor/seablast/seablast/views/BlueprintWeb.latte'}
+```
+
+When using `BlueprintWeb.latte`, define:
+
+```php
+->setInt(SeablastConstant::SB_WEB_FORCE_ASSET_VERSION, 1)
+```
+
+The layout expects `$csrfToken` and `$configuration`.
+Add local `views/nav.latte` and `views/footer.latte` when the app needs custom navigation or footer content.
+
+One route maps to one template.
+If a resource has list and detail states, either use one branching template or split the resource into exact paths.
+
+## Forms, JSON APIs, And CSRF
+
+All form submissions and JSON calls should submit the view-provided `csrfToken`.
+
+Use `GenericRestApiJsonModel` for JSON endpoints when the endpoint accepts:
+
+- JSON `Content-Type`
+- an object-shaped JSON body
+- body size up to the framework limit
+- `csrfToken` validated with token ID `sb_json`
+
+Models extending `GenericRestApiJsonModel` should call `parent::knowledge()` first and stop when it returns `httpCode >= 400`.
+
+Do not use `GenericRestApiJsonModel` for multipart uploads or normal form posts.
+For those, validate the same token ID manually, preferably from a submitted `csrfToken` field.
+
+## Uploads And Downloads
+
+`Superglobals` wraps GET, POST, SERVER, and SESSION.
+It does not wrap FILES, so upload models must read `$_FILES` directly or the app must provide its own wrapper.
+
+Binary downloads do not fit the normal Latte or `rest` response flow.
+The practical pattern is:
+
+1. validate authentication and authorization
+2. resolve the private file path
+3. compare `realpath()` against the configured private storage root
+4. send headers
+5. stream the file
+6. `exit` before `SeablastView` continues
+
+## Database Choices
+
+Seablast's built-in database helpers expect Phinx-style MySQL configuration in `conf/phinx.local.php`.
+They expose lazy `mysqli()` and `pdo()` adapters through `SeablastConfiguration`.
+
+An app may keep a custom database layer instead, especially during migration.
+If it does, document that choice in the app and keep Seablast route/model/view behavior separate from the custom persistence layer.
+
+Do not track `composer.lock` in applications so the Seablast runtime can run in multiple environments.
+
+## Web Server And Security Checklist
+
+An app `.htaccess` or server config should:
+
+- route app URLs to `vendor/seablast/seablast/index.php`
+- block direct access to `conf/`, `src/`, `views/`, `tests/`, `cache/`, `log/`, and private storage
+- block Markdown, config, shell, CI, Composer, PHPUnit, dotfiles, and local metadata from the web
+- keep required Seablast front-controller and asset paths reachable
+
+Security defaults for app agents:
+
+- treat all request data as untrusted
+- validate optional IDs in the model
+- do not derive `redirectionUrl` directly from request input
+- prefer prepared database statements
+- never stream a private file without a `realpath()` containment check
+- keep debug and Tracy development output limited to trusted environments
+
+## Testing Checklist
+
+Useful app-level tests:
+
+- load `conf/app.conf.php`
+- read `SeablastConstant::APP_MAPPING`
+- assert every mapped app model class exists
+- assert every mapped local template exists or intentionally uses a bundled template
+- test model behavior directly with `Superglobals`
+- keep service tests focused on application behavior
+- add at least one browser or HTTP smoke test for the real Seablast request flow
+
+When migrating an existing app, add a test that locks the route map before deleting old framework-parallel folders.
+
+## Migration Checklist
+
+For framework migrations, prefer real moves over compatibility aliases:
+
+- `classes/` to `src/`
+- `config/` to `conf/`
+- `templates/` to `views/`
+- `migrations/` to `conf/db/migrations/`
+
+Keep or add:
+
+- `assets/`
+- `cache/`
+- `log/`
+- private `var/`
+
+Remove stale front controllers, duplicate routers, and unused framework folders once the Seablast route map is covered by tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,21 @@
 # AGENTS.md
 
 This file is the maintainer and integration guide for `seablast/seablast`.
-It is written for two audiences:
+It is written primarily for maintainers changing the framework itself and for framework integrators who need to preserve Seablast's real runtime contract.
 
-- maintainers changing the framework itself
-- applications that build on top of Seablast and need to understand its real runtime contract
+Agents building applications on top of Seablast should start with `AGENT-STARTER-KIT.md` and return here only when they need deeper framework behavior.
 
 This document describes the current behavior of the codebase, including important caveats that are not obvious from the marketing-level `README.md` alone.
+
+## Companion Documentation
+
+Use these documents for the intended audience:
+
+- `AGENTS.md`: framework maintenance, internal contracts, and integration caveats
+- `AGENT-STARTER-KIT.md`: AI agents building or migrating applications that use Seablast as a dependency
+- `README.md`: public human-facing overview and usage guidance
+
+When changing app-facing behavior, keep `AGENT-STARTER-KIT.md` aligned with `AGENTS.md` so downstream agents do not learn stale application patterns.
 
 ## What Seablast Is
 
@@ -368,6 +377,7 @@ Important test assumptions:
 If a change affects framework behavior that applications depend on, update all of these together:
 
 - `README.md` for public usage guidance
+- `AGENT-STARTER-KIT.md` for AI agents building or migrating apps
 - `CHANGELOG.md` for release notes
 - `AGENTS.md` for maintainer and integration detail
 - tests where the behavior is asserted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,18 +26,23 @@ feat: expose string[] SeablastConstant::ADMIN_BOOLEAN_FIELDS
 ### Added
 
 - expose string[] SeablastConstant::ADMIN_BOOLEAN_FIELDS
+- Add `AGENT-STARTER-KIT.md` as an application-builder guide for AI agents using Seablast.
+- Add PHPUnit coverage for HTML error rendering without a JSON REST payload.
 
 ### Changed
 
 - Introduce AGENTS.md and CLAUDE.md DRY combination
 - TableViewModel.php: change limit from 200 to 250 records to be listed in admin view
 - bump: Seablast Logger to v2.0.6
+- Clarify the documentation split between maintainer guidance and app-builder guidance.
+- Clarify redirect documentation to include the supported 307 and 308 status codes.
 
 ### Fixed
 
 - Fix PHPStan type inference for the bounded JSON API input read length.
 - Validate admin boolean-like columns against stored values before exposing boolean metadata.
 - Expose only true boolean-like admin column names to the table view model.
+- Guard the HTTP error Tracy panel against missing REST payloads for HTML error responses.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This minimalist MVC framework added by [composer](https://getcomposer.org/) help
 The framework takes care of logs, database, multiple languages, user friendly HTTP errors, friendly URL.
 
 - See <https://github.com/WorkOfStan/seablast-dist/> for example of how to use it. It's a public template, so you can start creating your app by duplicating that repository.
+- AI agents and application builders should start with [AGENT-STARTER-KIT.md](AGENT-STARTER-KIT.md), which describes the practical app structure, routing, models, templates, CSRF, uploads, downloads, and testing expectations.
 
 ## Configuration
 
@@ -33,7 +34,7 @@ SeablastModel uses model field in APP_MAPPING to invoke the model in the App.
 The minimal requirements can be implemented by [SeablastModelInterface](src/SeablastModelInterface.php).
 
 - If model replies with `rest` property, API response is triggered instead of HTML UI. If the default HTTP code should be changed, set it up in the `httpCode` property.
-- If model replies with `redirectionUrl` property, then redirection is triggered (instead of HTML UI) with HTTP code 301. The HTTP code MAY be set to 301, 302 or 303 by the `httpCode` property.
+- If model replies with `redirectionUrl` property, then redirection is triggered (instead of HTML UI) with HTTP code 301. The HTTP code MAY be set to 301, 302, 303, 307, or 308 by the `httpCode` property.
 - If using the default BlueprintWeb.latte, the `title` property is displayed as the page title.
 
 ```php

--- a/src/README.md
+++ b/src/README.md
@@ -1,5 +1,8 @@
 # Seablast Logic Overview
 
+This source-level overview describes the framework runtime flow.
+Agents building applications with Seablast should start with the root [AGENT-STARTER-KIT.md](../AGENT-STARTER-KIT.md).
+
 1. **SeablastSetup**: Combines various configuration files into a unified configuration.
 
 2. **SeablastController**: Applies the configuration and determines the appropriate mapping based on the URL and superglobals. The mapping is retrieved from `APP_MAPPING` and assigned to `string[] mapping`. If `mapping['roleIds']` is set, the IdentityManager comes into play here.

--- a/src/SeablastView.php
+++ b/src/SeablastView.php
@@ -210,13 +210,10 @@ class SeablastView
             return;
         }
 
+        $rest = $this->params->rest ?? null;
         $httpBarPanel = new BarPanelTemplate(
             'HTTP: ' . $this->params->httpCode,
-            (
-                (($this->params->rest instanceof \stdClass) || is_object($this->params->rest))
-                && isset($this->params->rest->message)
-            )
-            ? ['message' => $this->params->rest->message] : []
+            (is_object($rest) && isset($rest->message)) ? ['message' => $rest->message] : []
         );
         $httpBarPanel->setError();
         Debugger::getBar()->addPanel($httpBarPanel);

--- a/tests/SeablastViewTest.php
+++ b/tests/SeablastViewTest.php
@@ -89,6 +89,36 @@ class SeablastViewTest extends TestCase
         $this->assertStringStartsWith('<!doctype html>', $output);
     }
 
+    public function testHtmlErrorWithoutRestPayloadRendersErrorTemplate(): void
+    {
+        $this->configuration
+            ->setInt(SeablastConstant::ERROR_HTTP_CODE, 404)
+            ->setString(SeablastConstant::ERROR_MESSAGE, 'Not found')
+        ;
+        $this->controller->mapping = [
+            'template' => 'item',
+            'model' => '\Seablast\Seablast\Models\ErrorModel',
+        ];
+        $model = new SeablastModel($this->controller, new Superglobals());
+        $output = false;
+        $bufferLevel = ob_get_level();
+
+        ob_start();
+        try {
+            new SeablastView($model);
+            $output = ob_get_clean();
+        } finally {
+            while (ob_get_level() > $bufferLevel) {
+                ob_end_clean();
+            }
+            http_response_code(200);
+        }
+
+        $this->assertNotFalse($output, 'Should contain HTML error output.');
+        $this->assertStringStartsWith('<!doctype html>', $output);
+        $this->assertStringContainsString('Not found', $output);
+    }
+
     public function testGetTemplatePathThrowsMissingTemplateException(): void
     {
         $this->expectException(MissingTemplateException::class);


### PR DESCRIPTION
### Added

- Add `AGENT-STARTER-KIT.md` as an application-builder guide for AI agents using Seablast.
- Add PHPUnit coverage for HTML error rendering without a JSON REST payload.

### Changed

- Clarify the documentation split between maintainer guidance and app-builder guidance.
- Clarify redirect documentation to include the supported 307 and 308 status codes.

### Fixed

- Guard the HTTP error Tracy panel against missing REST payloads for HTML error responses.